### PR TITLE
fix: ControlPath too long for Unix socket on macOS

### DIFF
--- a/scarf/scarf/Core/Transport/SSHTransport.swift
+++ b/scarf/scarf/Core/Transport/SSHTransport.swift
@@ -52,10 +52,13 @@ struct SSHTransport: ServerTransport {
     /// per-host via OpenSSH's `%C` token). Exposed as a static so
     /// cleanup paths (`ServerRegistry.removeServer`, app-launch sweep) can
     /// compute it without instantiating a transport.
+    ///
+    /// Uses a short path under /tmp to stay within the 104-byte macOS
+    /// Unix domain socket limit. The Caches path
+    /// (~/Library/Caches/scarf/ssh/%C) can exceed this limit when the
+    /// username is long, causing ssh to exit 255.
     nonisolated static func controlDirPath() -> String {
-        let base = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first?.path
-            ?? NSHomeDirectory() + "/Library/Caches"
-        return base + "/scarf/ssh"
+        return "/tmp/scarf-ssh-\(getuid())"
     }
 
     /// Snapshot cache directory for a given server. Stable per-ID so repeated


### PR DESCRIPTION
## Summary
- `~/Library/Caches/scarf/ssh/%C` generates socket paths that exceed the 104-byte macOS Unix domain socket limit when the username is long
- ssh exits 255 with `unix_listener: path "..." too long for Unix domain socket` — no useful stderr reaches the user, just "Remote command exited 255"
- Switch `controlDirPath()` to `/tmp/scarf-ssh-<uid>` which stays well within the limit

## Root cause
OpenSSH's `%C` token expands to a 40-char hex hash + random suffix. Combined with the Caches path (e.g. `/Users/alex.maksimchuk/Library/Caches/scarf/ssh/`), the total reaches 105 bytes — one byte over the 104-byte `sun_path` limit on macOS.

## Test plan
- [ ] Verify remote server connection works with a username > 10 chars
- [ ] Verify ControlMaster reuse still works (second ssh to same host should be instant)
- [ ] Verify `ServerRegistry.removeServer` cleanup still finds the socket dir