### PR TITLE
Persist sidebar width across launches (#26)

### DIFF
--- a/scarf/scarf/ContentView.swift
+++ b/scarf/scarf/ContentView.swift
@@ -14,6 +14,7 @@ struct ContentView: View {
     var body: some View {
         NavigationSplitView {
             SidebarView()
+                .navigationSplitViewColumnWidth(min: 180, ideal: 240, max: 360)
         } detail: {
             detailView
                 .toolbar {

--- a/scarf/scarf/Navigation/SidebarView.swift
+++ b/scarf/scarf/Navigation/SidebarView.swift
@@ -59,5 +59,6 @@ struct SidebarView: View {
         }
         .listStyle(.sidebar)
         .navigationTitle("Scarf")
+        .splitViewAutosaveName("ScarfMainSidebar")
     }
 }

--- a/scarf/scarf/Navigation/SplitViewAutosave.swift
+++ b/scarf/scarf/Navigation/SplitViewAutosave.swift
@@ -1,0 +1,57 @@
+import AppKit
+import SwiftUI
+
+/// Makes the enclosing `NSSplitView` remember its divider positions across
+/// app launches. `NavigationSplitView` is backed by `NSSplitViewController`,
+/// whose split view honours `autosaveName` — AppKit writes the divider
+/// offsets to `UserDefaults` on drag and restores them on the next launch.
+///
+/// Usage: attach `.splitViewAutosaveName("…")` to a child of the split view
+/// (the sidebar is a good choice). The modifier installs an invisible helper
+/// that walks up the view hierarchy on first layout, finds the `NSSplitView`,
+/// and assigns its autosave name. Subsequent launches restore the divider
+/// positions before the window appears.
+///
+/// The name is also used to key the entry in `UserDefaults` (AppKit stores
+/// it as `NSSplitView Subview Frames <name>`), so changing the name resets
+/// the remembered width. Pick a stable string and leave it alone.
+struct SplitViewAutosaveFinder: NSViewRepresentable {
+    let autosaveName: String
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        // Defer the hierarchy walk until after SwiftUI has attached this
+        // view to its host window — at makeNSView time the view has no
+        // superview yet, so we can't find the split view above us.
+        DispatchQueue.main.async { [weak view] in
+            guard let view else { return }
+            SplitViewAutosaveFinder.apply(autosaveName, startingFrom: view)
+        }
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {}
+
+    private static func apply(_ name: String, startingFrom view: NSView) {
+        var current: NSView? = view
+        while let node = current {
+            if let split = node as? NSSplitView {
+                // Only set once — reassigning clobbers AppKit's restore path.
+                if split.autosaveName != NSSplitView.AutosaveName(name) {
+                    split.autosaveName = NSSplitView.AutosaveName(name)
+                }
+                return
+            }
+            current = node.superview
+        }
+    }
+}
+
+extension View {
+    /// Persist the enclosing `NavigationSplitView` / `NSSplitView` divider
+    /// positions to `UserDefaults` under `autosaveName`. Attach to any child
+    /// of the split view (the sidebar works well).
+    func splitViewAutosaveName(_ autosaveName: String) -> some View {
+        background(SplitViewAutosaveFinder(autosaveName: autosaveName))
+    }
+}


### PR DESCRIPTION
## Summary

Addresses part 1 of #26 — the sidebar width no longer resets on every launch.

- Adds `SplitViewAutosave.swift`: a tiny `NSViewRepresentable` helper plus a `.splitViewAutosaveName("…")` view modifier. Attached to the sidebar, it walks up the view hierarchy on first layout, finds the `NSSplitView` that backs `NavigationSplitView`, and sets its `autosaveName`. AppKit then writes divider offsets to `UserDefaults` on drag and restores them on next launch — no `@AppStorage` plumbing, no `UserDefaults` keys of our own to maintain.
- Adds `.navigationSplitViewColumnWidth(min: 180, ideal: 240, max: 360)` in `ContentView.swift` so the very first launch (before any autosave exists) lands on a sensible width.

## Test plan

- [ ] Launch the app, drag the sidebar divider to a new width, quit, and relaunch → sidebar comes back at the new width.
- [ ] Fresh install / first launch (or after clearing `defaults delete com.scarf.scarf`) opens with sidebar near 240pt.
- [ ] Divider is draggable only within 180–360pt.
- [ ] Multi-window: both windows restore to the same width (expected; they share one `autosaveName`).
- [ ] No impact on toolbar switcher, connection pill, or detail view routing.

Note: this sandbox is Linux-only — no `xcodebuild` available here, so the changes were reviewed manually but not compiled. Please verify with a local build.

Closes part 1 of #26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)