### PR TITLE
Let users pick the default server opened on launch (#26)

### DIFF
--- a/scarf/scarf/Core/Persistence/ServerRegistry.swift
+++ b/scarf/scarf/Core/Persistence/ServerRegistry.swift
@@ -9,8 +9,10 @@ struct ServerEntry: Identifiable, Codable, Hashable, Sendable {
     var id: ServerID
     var displayName: String
     var kind: ServerKind
-    /// User preference: open this server in a window on launch. Phase 3
-    /// multi-window uses this; Phase 2 ignores it.
+    /// User preference: this server is the one Scarf opens into when a
+    /// fresh window has no prior binding (first launch or File → New).
+    /// At most one entry should have this set — `ServerRegistry` enforces
+    /// mutual exclusivity. If none do, Local is the implicit default.
     var openOnLaunch: Bool = false
 
     var context: ServerContext {
@@ -67,6 +69,32 @@ final class ServerRegistry {
             return entry.context
         }
         return nil
+    }
+
+    /// The server a fresh window should open into. Returns the ID of the
+    /// remote entry flagged `openOnLaunch`, or Local's ID if none is
+    /// flagged (or if the flagged entry was removed out from under us).
+    /// Consumed by the `WindowGroup`'s `defaultValue` closure.
+    var defaultServerID: ServerID {
+        entries.first(where: { $0.openOnLaunch })?.id ?? ServerContext.local.id
+    }
+
+    /// Flip the default server to `id`. Passing `ServerContext.local.id`
+    /// clears the flag on every remote entry, making Local the implicit
+    /// default. Passing an unknown ID is a no-op. Persisted on return.
+    func setDefaultServer(_ id: ServerID) {
+        var changed = false
+        for idx in entries.indices {
+            let shouldBeDefault = (entries[idx].id == id)
+            if entries[idx].openOnLaunch != shouldBeDefault {
+                entries[idx].openOnLaunch = shouldBeDefault
+                changed = true
+            }
+        }
+        if changed {
+            save()
+            onEntriesChanged?()
+        }
     }
 
     // MARK: - Mutations

--- a/scarf/scarf/Features/Servers/Views/ManageServersView.swift
+++ b/scarf/scarf/Features/Servers/Views/ManageServersView.swift
@@ -87,9 +87,28 @@ struct ManageServersView: View {
     }
 
     private var list: some View {
-        List {
+        let defaultID = registry.defaultServerID
+        return List {
+            // Local sits at the top so users can mark it as the open-on-launch
+            // default alongside remote servers. It's synthesized (not in
+            // `registry.entries`), so render it explicitly.
+            HStack(spacing: 10) {
+                defaultStar(for: ServerContext.local.id, currentDefault: defaultID)
+                Image(systemName: "laptopcomputer")
+                    .foregroundStyle(.blue)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Local").font(.body)
+                    Text("This Mac")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+            }
+            .padding(.vertical, 4)
+
             ForEach(registry.entries) { entry in
                 HStack(spacing: 10) {
+                    defaultStar(for: entry.id, currentDefault: defaultID)
                     Image(systemName: "server.rack")
                         .foregroundStyle(.blue)
                     VStack(alignment: .leading, spacing: 2) {
@@ -121,6 +140,23 @@ struct ManageServersView: View {
             }
         }
         .listStyle(.inset)
+    }
+
+    /// A star button that marks the open-on-launch default. Filled + yellow
+    /// on the current default row (and non-interactive — clicking it is a
+    /// no-op since the flag is already set); outline + secondary elsewhere,
+    /// clicking promotes that row to default.
+    @ViewBuilder
+    private func defaultStar(for id: ServerID, currentDefault: ServerID) -> some View {
+        let isDefault = id == currentDefault
+        Button {
+            if !isDefault { registry.setDefaultServer(id) }
+        } label: {
+            Image(systemName: isDefault ? "star.fill" : "star")
+                .foregroundStyle(isDefault ? .yellow : .secondary)
+        }
+        .buttonStyle(.borderless)
+        .help(isDefault ? "Opens on launch" : "Set as default — open this server when Scarf launches.")
     }
 
     private func summary(for config: SSHConfig) -> String {

--- a/scarf/scarf/scarfApp.swift
+++ b/scarf/scarf/scarfApp.swift
@@ -63,7 +63,11 @@ struct ScarfApp: App {
                     .environment(updater)
             }
         } defaultValue: {
-            ServerContext.local.id
+            // Honour the user's "open on launch" choice from the Manage
+            // Servers popover. Falls back to Local when no entry is flagged
+            // (the default behaviour for fresh installs) or when the
+            // flagged entry was removed while the app was closed.
+            registry.defaultServerID
         }
         .defaultSize(width: 1100, height: 700)
         .commands {


### PR DESCRIPTION
## Summary

Addresses part 2 of #26 — instead of hardcoding Local as the default, users can now nominate any registered server (Local or a specific remote) as the one Scarf opens into when a fresh window has no prior binding.

Implementation reuses the `ServerEntry.openOnLaunch` flag that was already in the persisted schema but previously unused (the old comment noted "Phase 3 multi-window uses this; Phase 2 ignores it").

- **`ServerRegistry`**: adds `defaultServerID` (returns the flagged entry's ID, or falls back to `ServerContext.local.id`) and `setDefaultServer(_:)` (flips the flag on the target and clears every other entry's, then `save()`s — enforcing the "at most one default" invariant).
- **`ScarfApp`**: the `WindowGroup`'s `defaultValue` closure now returns `registry.defaultServerID` instead of hardcoded `ServerContext.local.id`. The closure is re-evaluated each time a new window opens, so changing the default mid-session takes effect on the next File → New.
- **`ManageServersView`**: adds a Local row at the top of the list (previously the popover only showed remotes — now Local is visible and configurable alongside them), and a leading star button per row. Filled yellow star = current default; outline star = click to promote.

Backward compatible: the `openOnLaunch` field was already `Codable` with a `false` default, so existing `servers.json` files load unchanged. First-time behaviour is identical to before (Local opens) until the user picks otherwise.

## Edge cases

- Default entry deleted while app is closed → `defaultServerID` falls back to Local (existing `MissingServerView` already handles the analogous per-window case).
- Setting the current default as default again → `setDefaultServer` detects no change and skips the `save()` / `onEntriesChanged` fanout.
- No remote servers yet → `ManageServersView` still shows its empty state; Local is trivially the only option, so there's nothing to configure.

## Test plan

- [ ] Add a remote server, open the Servers popover, star the remote → quit Scarf → relaunch: first window opens into the starred remote.
- [ ] In the same state, star Local instead → quit → relaunch: first window opens into Local.
- [ ] Set a remote as default, delete it from the popover → relaunch: falls back to Local, no crash.
- [ ] File → New Window (⌘N) with a remote starred opens a new window into the starred server.
- [ ] ⌘1…⌘9 shortcuts in File → Open Server still target their specific servers regardless of default (unchanged).
- [ ] Clicking the star on an already-default row is a no-op (no flicker, no spurious disk write).
- [ ] `~/Library/Application Support/scarf/servers.json` contains `"openOnLaunch": true` on exactly one entry after starring.

Note: this sandbox is Linux-only — no `xcodebuild` available here, so the changes were reviewed manually but not compiled. Please verify with a local build.

Closes part 2 of #26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)