### PR TITLE
fix: address code-review findings from Apr 22 commits

### DIFF
--- a/scarf/scarf/Core/Persistence/ServerRegistry.swift
+++ b/scarf/scarf/Core/Persistence/ServerRegistry.swift
@@ -82,6 +82,11 @@ final class ServerRegistry {
     /// Flip the default server to `id`. Passing `ServerContext.local.id`
     /// clears the flag on every remote entry, making Local the implicit
     /// default. Passing an unknown ID is a no-op. Persisted on return.
+    ///
+    /// Intentionally doesn't fire `onEntriesChanged` — that hook means "the
+    /// set of servers changed" and drives the menu-bar fanout rebuild. A
+    /// default-flag flip doesn't change the set; SwiftUI views reading
+    /// `defaultServerID` redraw via `@Observable`'s tracking of `entries`.
     func setDefaultServer(_ id: ServerID) {
         var changed = false
         for idx in entries.indices {
@@ -93,7 +98,6 @@ final class ServerRegistry {
         }
         if changed {
             save()
-            onEntriesChanged?()
         }
     }
 

--- a/scarf/scarf/Features/Servers/Views/ManageServersView.swift
+++ b/scarf/scarf/Features/Servers/Views/ManageServersView.swift
@@ -143,19 +143,20 @@ struct ManageServersView: View {
     }
 
     /// A star button that marks the open-on-launch default. Filled + yellow
-    /// on the current default row (and non-interactive — clicking it is a
-    /// no-op since the flag is already set); outline + secondary elsewhere,
-    /// clicking promotes that row to default.
+    /// on the current default row (disabled, since clicking would be a
+    /// no-op); outline + secondary elsewhere, clicking promotes that row
+    /// to default.
     @ViewBuilder
     private func defaultStar(for id: ServerID, currentDefault: ServerID) -> some View {
         let isDefault = id == currentDefault
         Button {
-            if !isDefault { registry.setDefaultServer(id) }
+            registry.setDefaultServer(id)
         } label: {
             Image(systemName: isDefault ? "star.fill" : "star")
                 .foregroundStyle(isDefault ? .yellow : .secondary)
         }
         .buttonStyle(.borderless)
+        .disabled(isDefault)
         .help(isDefault ? "Opens on launch" : "Set as default — open this server when Scarf launches.")
     }
 

--- a/scarf/scarf/Navigation/SidebarView.swift
+++ b/scarf/scarf/Navigation/SidebarView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct SidebarView: View {
     @Environment(AppCoordinator.self) private var coordinator
+    @Environment(\.serverContext) private var serverContext
 
     var body: some View {
         @Bindable var coordinator = coordinator
@@ -59,6 +60,6 @@ struct SidebarView: View {
         }
         .listStyle(.sidebar)
         .navigationTitle("Scarf")
-        .splitViewAutosaveName("ScarfMainSidebar")
+        .splitViewAutosaveName("ScarfMainSidebar.\(serverContext.id)")
     }
 }


### PR DESCRIPTION
## Summary

Three follow-ups from reviewing [`1989fee`](https://github.com/awizemann/scarf/commit/1989feee22e23e97c7b3ab7efe49748853295f82) (sidebar-width persist) and [`4163595`](https://github.com/awizemann/scarf/commit/41635955b058571a2f527556c187e7fe92d6fbe5) (default server on launch):

- **Per-window sidebar autosave.** `SplitViewAutosaveFinder` hardcoded `"ScarfMainSidebar"`. Since Scarf's `WindowGroup` spawns one window per `ServerID`, every window's `NSSplitView` shared the same `autosaveName` — AppKit documents that name as required-unique, and in practice all per-window widths collapsed onto one `UserDefaults` key. Now threads the window's `ServerContext` in via `@Environment(\.serverContext)` (already wired by `scarfApp`) and suffixes the name with the server UUID.
- **Drop semantic-noise callback.** `ServerRegistry.setDefaultServer` fired `onEntriesChanged`, whose only consumer is `ServerLiveStatusRegistry.rebuild()` for menu-bar fanout. Flipping a default flag doesn't change the set of servers. Removed the call — SwiftUI views still redraw on the flag flip via `@Observable`'s tracking of `entries`.
- **Disable no-op star button.** The filled-yellow star in `ManageServersView` had a no-op `if !isDefault { ... }` action but still animated its pressed state on click. Replaced with `.disabled(isDefault)`.

## Test plan

- [ ] Build: `xcodebuild -project scarf/scarf.xcodeproj -scheme scarf -configuration Debug build` (verified locally, BUILD SUCCEEDED).
- [ ] Open two windows via `File -> Open Server` (Local + a remote), drag each sidebar to a different width, quit, relaunch — both windows restore their own widths independently.
- [ ] In `Manage Servers`, add two remote servers and click the star on each alternately — yellow fill promotes cleanly; confirm no menu-bar churn in the live-status registry.
- [ ] Click the already-filled yellow star — no press-state animation; cursor stays as pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)