### PR TITLE
refactor(settings): remove unused providers list

### DIFF
--- a/scarf/scarf/Features/Settings/ViewModels/SettingsViewModel.swift
+++ b/scarf/scarf/Features/Settings/ViewModels/SettingsViewModel.swift
@@ -20,7 +20,6 @@ final class SettingsViewModel {
     var hermesRunning = false
     var rawConfigYAML = ""
     var personalities: [String] = []
-    var providers = ["anthropic", "openrouter", "nous", "openai-codex", "google-ai-studio", "xai", "ollama-cloud", "zai", "kimi-coding", "minimax"]
     var terminalBackends = ["local", "docker", "singularity", "modal", "daytona", "ssh"]
     var browserBackends = ["browseruse", "firecrawl", "local"]
     var ttsProviders = ["edge", "elevenlabs", "openai", "minimax", "mistral", "neutts"]


### PR DESCRIPTION
## Summary

- Delete the hardcoded `providers` array on `SettingsViewModel` — no view references it (grep for `.providers` finds zero hits).
- The Model picker loads providers from the models.dev catalog via `ModelCatalogService.loadProviders()`; Provider is rendered as a `ReadOnlyRow` on the General tab. The stale list played no role in save behaviour.

## Why

Surfaced while investigating [#33](https://github.com/awizemann/scarf/issues/33). The reporter's guess at root cause was that a provider enum in Settings normalises `openai-codex` → `openai` on save. That enum is this dead list. Removing it narrows the surface for anyone else trying to reason about where `model.provider` could get rewritten — it can only change via the explicit Model picker → `setProvider` path.

Does not fix #33 on its own; the rewrite appears to originate in `hermes config set` on Hermes v0.7.0 re-serialising `config.yaml`. Cleanup only.

## Test plan

- [x] `xcodebuild -project scarf/scarf.xcodeproj -scheme scarf -configuration Debug build` — BUILD SUCCEEDED
- [ ] Open Settings → General → all rows still render (Model / Provider / Personality / Timezone)
- [ ] Open Settings → Memory / Browser / Voice / Terminal tabs — other picker lists unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)