### PR TITLE
Improve local macOS build flow and Hermes process matching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,55 @@
+# File created using '.gitignore Generator' for Visual Studio Code: https://bit.ly/vscode-gig
+# Created by https://www.toptal.com/developers/gitignore/api/xcode,vim,swift,macos,visualstudio,visualstudiocode
+# Edit at https://www.toptal.com/developers/gitignore?templates=xcode,vim,swift,macos,visualstudio,visualstudiocode
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+### Swift ###
 # Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
 build/
-.gh-pages-worktree/
-.wiki-worktree/
 DerivedData/
+*.moved-aside
 *.pbxuser
 !default.pbxuser
 *.mode1v3
@@ -11,58 +58,517 @@ DerivedData/
 !default.mode2v3
 *.perspectivev3
 !default.perspectivev3
-xcuserdata/
-*.xccheckout
-*.moved-aside
+
+## Obj-C/Swift specific
 *.hmap
+
+## App packaging
 *.ipa
 *.dSYM.zip
 *.dSYM
 
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
 # Swift Package Manager
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+# Package.pins
+# Package.resolved
+# *.xcodeproj
+# Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
+# hence it is not needed unless you have added a package configuration file to your project
+# .swiftpm
+
 .build/
-# `Packages/` is the historical SwiftPM checkout dir for downloaded deps
-# (pre-Xcode-14). We keep it ignored — but NOT our local-package checkout
-# at scarf/Packages/, which is part of the source tree (ScarfCore, etc.)
-# and must ship in the repo.
-Packages/
-!scarf/Packages/
-Package.pins
-Package.resolved
-*.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/
-.swiftpm/
 
-# macOS
-.DS_Store
-.AppleDouble
-.LSOverride
-._*
-.Spotlight-V100
-.Trashes
+# CocoaPods
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+# Pods/
+# Add this line if you want to avoid checking in source code from the Xcode workspace
+# *.xcworkspace
 
-# IDE
-*.swp
-*.swo
+# Carthage
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build/
+
+# Accio dependency management
+Dependencies/
+.accio/
+
+# fastlane
+# It is recommended to not store the screenshots in the git repo.
+# Instead, use fastlane to re-generate the screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output
+
+# Code Injection
+# After new code Injection tools there's a generated folder /iOSInjectionProject
+# https://github.com/johnno1962/injectionforxcode
+
+iOSInjectionProject/
+
+### Vim ###
+# Swap
+[._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
 *~
-.idea/
-.vscode/
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~
 
-# Claude Code
-.claude/
-scarf/standards/backups/
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
 
-# Scarf project dashboards (user-specific)
-.scarf/
+# Local History for Visual Studio Code
+.history/
 
-# Release artifacts — GitHub Releases hosts the binaries; no need to bloat git
-# history. RELEASE_NOTES.md stays tracked (committed with the version bump).
-releases/v*/*.zip
-releases/v*/appcast-entry.xml
+# Built Visual Studio Code Extensions
+*.vsix
 
-# Wiki helper: personal patterns (hostnames, IPs) blocked from the wiki push.
-scripts/wiki-blocklist.txt
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
 
-# TestFlight feedback / crash JSONs downloaded for triage. PII (emails,
-# carriers, locales) and never meant for the public repo — kept local
-# while a fix round is in progress, deleted afterward.
-crashes/
+### Xcode ###
+
+## Xcode 8 and earlier
+
+### Xcode Patch ###
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcodeproj/project.xcworkspace/
+!*.xcworkspace/contents.xcworkspacedata
+/*.gcno
+**/xcshareddata/WorkspaceSettings.xcsettings
+
+### VisualStudio ###
+## Ignore Visual Studio temporary files, build results, and
+## files generated by popular Visual Studio add-ons.
+##
+## Get latest from https://github.com/github/gitignore/blob/main/VisualStudio.gitignore
+
+# User-specific files
+*.rsuser
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+# User-specific files (MonoDevelop/Xamarin Studio)
+*.userprefs
+
+# Mono auto generated files
+mono_crash.*
+
+# Build results
+[Dd]ebug/
+[Dd]ebugPublic/
+[Rr]elease/
+[Rr]eleases/
+x64/
+x86/
+[Ww][Ii][Nn]32/
+[Aa][Rr][Mm]/
+[Aa][Rr][Mm]64/
+bld/
+[Bb]in/
+[Oo]bj/
+[Ll]og/
+[Ll]ogs/
+
+# Visual Studio 2015/2017 cache/options directory
+.vs/
+# Uncomment if you have tasks that create the project's static files in wwwroot
+#wwwroot/
+
+# Visual Studio 2017 auto generated files
+Generated\ Files/
+
+# MSTest test Results
+[Tt]est[Rr]esult*/
+[Bb]uild[Ll]og.*
+
+# NUnit
+*.VisualState.xml
+TestResult.xml
+nunit-*.xml
+
+# Build Results of an ATL Project
+[Dd]ebugPS/
+[Rr]eleasePS/
+dlldata.c
+
+# Benchmark Results
+BenchmarkDotNet.Artifacts/
+
+# .NET Core
+project.lock.json
+project.fragment.lock.json
+artifacts/
+
+# ASP.NET Scaffolding
+ScaffoldingReadMe.txt
+
+# StyleCop
+StyleCopReport.xml
+
+# Files built by Visual Studio
+*_i.c
+*_p.c
+*_h.h
+*.ilk
+*.meta
+*.obj
+*.iobj
+*.pch
+*.pdb
+*.ipdb
+*.pgc
+*.pgd
+*.rsp
+*.sbr
+*.tlb
+*.tli
+*.tlh
+*.tmp
+*.tmp_proj
+*_wpftmp.csproj
+*.log
+*.tlog
+*.vspscc
+*.vssscc
+.builds
+*.pidb
+*.svclog
+*.scc
+
+# Chutzpah Test files
+_Chutzpah*
+
+# Visual C++ cache files
+ipch/
+*.aps
+*.ncb
+*.opendb
+*.opensdf
+*.sdf
+*.cachefile
+*.VC.db
+*.VC.VC.opendb
+
+# Visual Studio profiler
+*.psess
+*.vsp
+*.vspx
+*.sap
+
+# Visual Studio Trace Files
+*.e2e
+
+# TFS 2012 Local Workspace
+$tf/
+
+# Guidance Automation Toolkit
+*.gpState
+
+# ReSharper is a .NET coding add-in
+_ReSharper*/
+*.[Rr]e[Ss]harper
+*.DotSettings.user
+
+# TeamCity is a build add-in
+_TeamCity*
+
+# DotCover is a Code Coverage Tool
+*.dotCover
+
+# AxoCover is a Code Coverage Tool
+.axoCover/*
+!.axoCover/settings.json
+
+# Coverlet is a free, cross platform Code Coverage Tool
+coverage*.json
+coverage*.xml
+coverage*.info
+
+# Visual Studio code coverage results
+*.coverage
+*.coveragexml
+
+# NCrunch
+_NCrunch_*
+.*crunch*.local.xml
+nCrunchTemp_*
+
+# MightyMoose
+*.mm.*
+AutoTest.Net/
+
+# Web workbench (sass)
+.sass-cache/
+
+# Installshield output folder
+[Ee]xpress/
+
+# DocProject is a documentation generator add-in
+DocProject/buildhelp/
+DocProject/Help/*.HxT
+DocProject/Help/*.HxC
+DocProject/Help/*.hhc
+DocProject/Help/*.hhk
+DocProject/Help/*.hhp
+DocProject/Help/Html2
+DocProject/Help/html
+
+# Click-Once directory
+publish/
+
+# Publish Web Output
+*.[Pp]ublish.xml
+*.azurePubxml
+# Note: Comment the next line if you want to checkin your web deploy settings,
+# but database connection strings (with potential passwords) will be unencrypted
+*.pubxml
+*.publishproj
+
+# Microsoft Azure Web App publish settings. Comment the next line if you want to
+# checkin your Azure Web App publish settings, but sensitive information contained
+# in these scripts will be unencrypted
+PublishScripts/
+
+# NuGet Packages
+*.nupkg
+# NuGet Symbol Packages
+*.snupkg
+# The packages folder can be ignored because of Package Restore
+**/[Pp]ackages/*
+# except build/, which is used as an MSBuild target.
+!**/[Pp]ackages/build/
+# Uncomment if necessary however generally it will be regenerated when needed
+#!**/[Pp]ackages/repositories.config
+# NuGet v3's project.json files produces more ignorable files
+*.nuget.props
+*.nuget.targets
+
+# Microsoft Azure Build Output
+csx/
+*.build.csdef
+
+# Microsoft Azure Emulator
+ecf/
+rcf/
+
+# Windows Store app package directories and files
+AppPackages/
+BundleArtifacts/
+Package.StoreAssociation.xml
+_pkginfo.txt
+*.appx
+*.appxbundle
+*.appxupload
+
+# Visual Studio cache files
+# files ending in .cache can be ignored
+*.[Cc]ache
+# but keep track of directories ending in .cache
+!?*.[Cc]ache/
+
+# Others
+ClientBin/
+~$*
+*.dbmdl
+*.dbproj.schemaview
+*.jfm
+*.pfx
+*.publishsettings
+orleans.codegen.cs
+
+# Including strong name files can present a security risk
+# (https://github.com/github/gitignore/pull/2483#issue-259490424)
+#*.snk
+
+# Since there are multiple workflows, uncomment next line to ignore bower_components
+# (https://github.com/github/gitignore/pull/1529#issuecomment-104372622)
+#bower_components/
+
+# RIA/Silverlight projects
+Generated_Code/
+
+# Backup & report files from converting an old project file
+# to a newer Visual Studio version. Backup files are not needed,
+# because we have git ;-)
+_UpgradeReport_Files/
+Backup*/
+UpgradeLog*.XML
+UpgradeLog*.htm
+ServiceFabricBackup/
+*.rptproj.bak
+
+# SQL Server files
+*.mdf
+*.ldf
+*.ndf
+
+# Business Intelligence projects
+*.rdl.data
+*.bim.layout
+*.bim_*.settings
+*.rptproj.rsuser
+*- [Bb]ackup.rdl
+*- [Bb]ackup ([0-9]).rdl
+*- [Bb]ackup ([0-9][0-9]).rdl
+
+# Microsoft Fakes
+FakesAssemblies/
+
+# GhostDoc plugin setting file
+*.GhostDoc.xml
+
+# Node.js Tools for Visual Studio
+.ntvs_analysis.dat
+node_modules/
+
+# Visual Studio 6 build log
+*.plg
+
+# Visual Studio 6 workspace options file
+*.opt
+
+# Visual Studio 6 auto-generated workspace file (contains which files were open etc.)
+*.vbw
+
+# Visual Studio 6 auto-generated project file (contains which files were open etc.)
+*.vbp
+
+# Visual Studio 6 workspace and project file (working project files containing files to include in project)
+*.dsw
+*.dsp
+
+# Visual Studio 6 technical files
+
+# Visual Studio LightSwitch build output
+**/*.HTMLClient/GeneratedArtifacts
+**/*.DesktopClient/GeneratedArtifacts
+**/*.DesktopClient/ModelManifest.xml
+**/*.Server/GeneratedArtifacts
+**/*.Server/ModelManifest.xml
+_Pvt_Extensions
+
+# Paket dependency manager
+.paket/paket.exe
+paket-files/
+
+# FAKE - F# Make
+.fake/
+
+# CodeRush personal settings
+.cr/personal
+
+# Python Tools for Visual Studio (PTVS)
+__pycache__/
+*.pyc
+
+# Cake - Uncomment if you are using it
+# tools/**
+# !tools/packages.config
+
+# Tabs Studio
+*.tss
+
+# Telerik's JustMock configuration file
+*.jmconfig
+
+# BizTalk build output
+*.btp.cs
+*.btm.cs
+*.odx.cs
+*.xsd.cs
+
+# OpenCover UI analysis results
+OpenCover/
+
+# Azure Stream Analytics local run output
+ASALocalRun/
+
+# MSBuild Binary and Structured Log
+*.binlog
+
+# NVidia Nsight GPU debugger configuration file
+*.nvuser
+
+# MFractors (Xamarin productivity tool) working folder
+.mfractor/
+
+# Local History for Visual Studio
+.localhistory/
+
+# Visual Studio History (VSHistory) files
+.vshistory/
+
+# BeatPulse healthcheck temp database
+healthchecksdb
+
+# Backup folder for Package Reference Convert tool in Visual Studio 2017
+MigrationBackup/
+
+# Ionide (cross platform F# VS Code tools) working folder
+.ionide/
+
+# Fody - auto-generated XML schema
+FodyWeavers.xsd
+
+# VS Code files for those working on multiple tools
+*.code-workspace
+
+# Local History for Visual Studio Code
+
+# Windows Installer files from build outputs
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# JetBrains Rider
+*.sln.iml
+
+### VisualStudio Patch ###
+# Additional files built by Visual Studio
+
+# End of https://www.toptal.com/developers/gitignore/api/xcode,vim,swift,macos,visualstudio,visualstudiocode
+
+# Custom rules (everything added below won't be overriden by 'Generate .gitignore File' if you use 'Update' option)
+
+# Build-time artifacts for Swift Package Manager
+*.log
+scarf/scarf.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,23 @@
+# Building Scarf
+
+Scarf is a native macOS app built with Xcode. For contributor builds, use the local script:
+
+```bash
+./scripts/local-build.sh
+```
+
+Requirements:
+
+- macOS with Xcode selected by `xcode-select`
+- Xcode 16.0 or newer
+- Metal toolchain installed
+
+If the Metal toolchain is missing, the script will offer to install it in interactive shells. You can also install it manually:
+
+```bash
+xcodebuild -downloadComponent MetalToolchain
+```
+
+`scripts/local-build.sh` resolves Swift package dependencies, detects `arm64` vs `x86_64`, and builds the Debug app unsigned. Signing is intentionally disabled for local Debug builds so contributors do not need the maintainer's Apple Developer account.
+
+Release signing is separate from contributor builds. Maintainers should continue using the existing release process for signed distributable builds.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,10 @@ Thanks for your interest in contributing to Scarf.
 ## Getting Started
 
 1. Fork and clone the repo
-2. Open `scarf/scarf.xcodeproj` in Xcode 26.3+
-3. Build and run (requires macOS 26.2+ and Hermes installed at `~/.hermes/`)
+2. Open `scarf/scarf.xcodeproj` in Xcode 16.0+
+3. Build and run, or use `./scripts/local-build.sh` for an unsigned local Debug build
+
+See [BUILDING.md](BUILDING.md) for command-line build prerequisites.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ ditto -xk ~/Downloads/Scarf-vX.X.X-Universal.zip ~/Downloads/
 
 ### Build from Source
 
+See [BUILDING.md](BUILDING.md) for contributor-focused command-line build setup.
+
 ```bash
 git clone https://github.com/awizemann/scarf.git
 cd scarf/scarf
@@ -235,7 +237,7 @@ open scarf.xcodeproj
 Or from the command line:
 
 ```bash
-xcodebuild -project scarf/scarf.xcodeproj -scheme scarf -configuration Release -arch arm64 -arch x86_64 ONLY_ACTIVE_ARCH=NO build
+./scripts/local-build.sh
 ```
 
 ## Architecture

--- a/scarf/scarf/Core/Services/HermesFileService.swift
+++ b/scarf/scarf/Core/Services/HermesFileService.swift
@@ -1233,14 +1233,17 @@ struct HermesFileService: Sendable {
     }
 
     /// Error-surfacing variant. `.success(nil)` means `pgrep` ran successfully
-    /// and found no hermes process (Hermes is genuinely not running).
+    /// and found no Hermes gateway process (Hermes is genuinely not running).
     /// `.failure` means we couldn't probe at all (pgrep missing, connection
     /// down, permission issue) — a *different* UX from "not running".
     nonisolated func hermesPIDResult() -> Result<pid_t?, Error> {
         do {
             let result = try transport.runProcess(
                 executable: "/usr/bin/pgrep",
-                args: ["-f", "hermes"],
+                // Match the real gateway process shape without catching shell
+                // commands, dashboards, or log collectors that merely contain
+                // "hermes" in their argv.
+                args: ["-f", #"(^|[[:space:]])-m[[:space:]]+hermes_cli\.main[[:space:]]+gateway[[:space:]]+run([[:space:]]|$)|(^|[[:space:]/])hermes[[:space:]]+gateway[[:space:]]+run([[:space:]]|$)"#],
                 stdin: nil,
                 timeout: 5
             )

--- a/scarf/scarf/Features/Health/ViewModels/HealthViewModel.swift
+++ b/scarf/scarf/Features/Health/ViewModels/HealthViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Darwin
 import ScarfCore
 #if canImport(AppKit)
 import AppKit
@@ -592,8 +593,8 @@ final class HealthViewModel {
     }
 
     /// Stop the dashboard. If Scarf spawned it, send SIGTERM directly. If an
-    /// external instance is running, fall back to `pkill -f "hermes dashboard"`
-    /// so the Stop button works regardless of who launched it.
+    /// external instance is running, find the Hermes listener on the dashboard
+    /// port and kill that PID only.
     func stopDashboard() {
         guard !context.isRemote else { return }
         dashboardStatus = WebDashboardStatus(
@@ -606,13 +607,8 @@ final class HealthViewModel {
         if let proc = dashboardProcess, proc.isRunning {
             proc.terminate()
             dashboardProcess = nil
-        } else {
-            // External instance — best-effort pkill.
-            let kill = Process()
-            kill.executableURL = URL(fileURLWithPath: "/usr/bin/pkill")
-            kill.arguments = ["-f", "hermes dashboard"]
-            _ = try? kill.run()
-            kill.waitUntilExit()
+        } else if let pid = Self.dashboardListenerPID(port: dashboardStatus.port) {
+            _ = Darwin.kill(pid, SIGTERM)
         }
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) { [weak self] in
@@ -628,6 +624,34 @@ final class HealthViewModel {
                     self.actionMessage = nil
                 }
             }
+        }
+    }
+
+    /// Returns the process listening on the dashboard port, limited by command
+    /// name so a shell command or log tail containing "hermes dashboard" is not
+    /// matched by substring.
+    private static func dashboardListenerPID(port: Int) -> pid_t? {
+        let lsof = Process()
+        lsof.executableURL = URL(fileURLWithPath: "/usr/sbin/lsof")
+        lsof.arguments = ["-tiTCP:\(port)", "-sTCP:LISTEN", "-c", "hermes"]
+
+        let output = Pipe()
+        lsof.standardOutput = output
+        lsof.standardError = FileHandle.nullDevice
+
+        do {
+            try lsof.run()
+            lsof.waitUntilExit()
+            guard lsof.terminationStatus == 0 else { return nil }
+            let data = output.fileHandleForReading.readDataToEndOfFile()
+            let text = String(data: data, encoding: .utf8) ?? ""
+            return text
+                .split(whereSeparator: \.isNewline)
+                .compactMap { pid_t($0.trimmingCharacters(in: .whitespaces)) }
+                .first
+        } catch {
+            Self.dashboardLogger.warning("Failed to locate Hermes dashboard listener: \(error.localizedDescription, privacy: .public)")
+            return nil
         }
     }
 

--- a/scripts/local-build.sh
+++ b/scripts/local-build.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+IFS=$'\n\t'
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+PROJECT="$REPO_ROOT/scarf/scarf.xcodeproj"
+SCHEME="${SCHEME:-scarf}"
+CONFIG="${CONFIG:-Debug}"
+DERIVED_DATA="$REPO_ROOT/build/DerivedData"
+PACKAGE_RESOLVED_REL="scarf/scarf.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved"
+PACKAGE_RESOLVED="$REPO_ROOT/$PACKAGE_RESOLVED_REL"
+
+log() { printf '==> %s\n' "$*"; }
+die() { printf 'error: %s\n' "$*" >&2; exit 1; }
+
+cleanup_generated_files() {
+  if [[ "${REMOVE_GENERATED_PACKAGE_RESOLVED:-0}" == "1" && -f "$PACKAGE_RESOLVED" ]]; then
+    rm -f "$PACKAGE_RESOLVED"
+    rmdir "$REPO_ROOT/scarf/scarf.xcodeproj/project.xcworkspace/xcshareddata/swiftpm" 2>/dev/null || true
+    rmdir "$REPO_ROOT/scarf/scarf.xcodeproj/project.xcworkspace/xcshareddata" 2>/dev/null || true
+  fi
+}
+trap cleanup_generated_files EXIT
+
+log "Detecting architecture"
+case "$(uname -m)" in
+  arm64) BUILD_ARCH="arm64" ;;
+  x86_64) BUILD_ARCH="x86_64" ;;
+  *) die "unsupported architecture: $(uname -m)" ;;
+esac
+log "Using architecture: $BUILD_ARCH"
+
+log "Checking Xcode command line tools"
+command -v xcode-select >/dev/null 2>&1 || die "xcode-select not found; install Xcode or Xcode command line tools"
+if ! xcode-select -p >/dev/null 2>&1; then
+  die "Xcode command line tools not selected. Run: xcode-select --install"
+fi
+
+command -v xcrun >/dev/null 2>&1 || die "xcrun not found; install Xcode or Xcode command line tools"
+command -v xcodebuild >/dev/null 2>&1 || die "xcodebuild not found; install Xcode"
+
+log "Checking Metal toolchain"
+if ! xcrun metal --version >/dev/null 2>&1 && ! xcrun -f metal >/dev/null 2>&1; then
+  if [[ -t 0 && -z "${CI:-}" ]]; then
+    printf 'Metal toolchain is missing. Install it now with xcodebuild -downloadComponent MetalToolchain? [y/N] '
+    read -r reply
+    if [[ "$reply" =~ ^[Yy]$ ]]; then
+      xcodebuild -downloadComponent MetalToolchain
+      if xcrun metal --version >/dev/null 2>&1 || xcrun -f metal >/dev/null 2>&1; then
+        log "Metal toolchain installed"
+      else
+        die "Metal toolchain still not available after install"
+      fi
+    else
+      cat >&2 <<'EOF'
+error: Metal toolchain missing.
+
+Install it when you are ready with:
+  xcodebuild -downloadComponent MetalToolchain
+EOF
+      exit 1
+    fi
+  else
+    cat >&2 <<'EOF'
+error: Metal toolchain missing.
+
+Install it with:
+  xcodebuild -downloadComponent MetalToolchain
+EOF
+    exit 1
+  fi
+fi
+
+log "Resolving Swift packages"
+if [[ ! -e "$PACKAGE_RESOLVED" ]] && ! git -C "$REPO_ROOT" ls-files --error-unmatch "$PACKAGE_RESOLVED_REL" >/dev/null 2>&1; then
+  REMOVE_GENERATED_PACKAGE_RESOLVED=1
+fi
+xcodebuild \
+  -resolvePackageDependencies \
+  -project "$PROJECT"
+
+log "Building unsigned $CONFIG app"
+xcodebuild \
+  -project "$PROJECT" \
+  -scheme "$SCHEME" \
+  -configuration "$CONFIG" \
+  -derivedDataPath "$DERIVED_DATA" \
+  -arch "$BUILD_ARCH" \
+  ONLY_ACTIVE_ARCH=YES \
+  CODE_SIGNING_ALLOWED=NO \
+  CODE_SIGNING_REQUIRED=NO \
+  CODE_SIGN_IDENTITY="" \
+  DEVELOPMENT_TEAM="" \
+  build
+
+APP_PATH="$DERIVED_DATA/Build/Products/$CONFIG/scarf.app"
+[[ -d "$APP_PATH" ]] || die "build completed, but app bundle was not found at $APP_PATH"
+
+printf '\nBuild complete:\n  %s\n\n' "$APP_PATH"
+
+if [[ -t 0 && -z "${CI:-}" ]]; then
+  read -r -p "Copy to /Applications? [y/N] " reply
+  if [[ "$reply" =~ ^[Yy]$ ]]; then
+    rm -rf "/Applications/scarf.app"
+    ditto "$APP_PATH" "/Applications/scarf.app"
+    echo "Installed to /Applications/scarf.app"
+  fi
+fi


### PR DESCRIPTION
## Summary

This PR improves contributor-facing local macOS builds and tightens Hermes process detection/cleanup behavior.

## Changes

### Local builds on macOS
- Adds `scripts/local-build.sh` for unsigned local Debug builds
- Adds short contributor build instructions in `BUILDING.md`
- Updates README/CONTRIBUTING to point contributors at the local build script
- Checks for Xcode/Metal toolchain prerequisites before building

### Process Management
- Makes Hermes process matching more restrictive so unrelated commands, dashboards, or log watchers are not matched accidentally
- Avoids broad `pkill -f hermes` style cleanup for dashboard shutdown

## Notes

Release/App Store signing configuration is intentionally left intact. The local build script disables signing only for command-line Debug builds so contributors without an Apple Developer account can still build locally.
