### PR TITLE
Fix Kanban timeout on large SSH output

### DIFF
--- a/scarf/Packages/ScarfCore/Sources/ScarfCore/Transport/LocalTransport.swift
+++ b/scarf/Packages/ScarfCore/Sources/ScarfCore/Transport/LocalTransport.swift
@@ -190,9 +190,19 @@ public struct LocalTransport: ServerTransport {
         proc.standardOutput = stdoutPipe
         proc.standardError = stderrPipe
         if stdin != nil { proc.standardInput = stdinPipe }
+        let pipeCapture = ProcessPipeDrainer.start(
+            stdout: stdoutPipe.fileHandleForReading,
+            stderr: stderrPipe.fileHandleForReading
+        )
         do {
             try proc.run()
         } catch {
+            try? stdoutPipe.fileHandleForWriting.close()
+            try? stderrPipe.fileHandleForWriting.close()
+            if stdin != nil {
+                try? stdinPipe.fileHandleForReading.close()
+            }
+            _ = pipeCapture.wait()
             throw TransportError.other(message: "Failed to launch \(executable): \(error.localizedDescription)")
         }
         // Parent has its own copy of every pipe end after fork. The child
@@ -218,20 +228,20 @@ public struct LocalTransport: ServerTransport {
             }
             if proc.isRunning {
                 proc.terminate()
-                let partial = (try? stdoutPipe.fileHandleForReading.readToEnd()) ?? Data()
+                proc.waitUntilExit()
+                let captured = pipeCapture.wait()
                 try? stdoutPipe.fileHandleForReading.close()
                 try? stderrPipe.fileHandleForReading.close()
-                throw TransportError.timeout(seconds: timeout, partialStdout: partial)
+                throw TransportError.timeout(seconds: timeout, partialStdout: captured.stdout)
             }
         } else {
             proc.waitUntilExit()
         }
-        let out = (try? stdoutPipe.fileHandleForReading.readToEnd()) ?? Data()
-        let err = (try? stderrPipe.fileHandleForReading.readToEnd()) ?? Data()
+        let captured = pipeCapture.wait()
         try? stdoutPipe.fileHandleForReading.close()
         try? stderrPipe.fileHandleForReading.close()
         try? stdinPipe.fileHandleForWriting.close()
-        return ProcessResult(exitCode: proc.terminationStatus, stdout: out, stderr: err)
+        return ProcessResult(exitCode: proc.terminationStatus, stdout: captured.stdout, stderr: captured.stderr)
         #endif
     }
 

--- a/scarf/Packages/ScarfCore/Sources/ScarfCore/Transport/ProcessPipeDrainer.swift
+++ b/scarf/Packages/ScarfCore/Sources/ScarfCore/Transport/ProcessPipeDrainer.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+#if !os(iOS)
+/// Concurrently drains stdout and stderr for subprocesses that are otherwise
+/// waited on synchronously by `runProcess`.
+///
+/// Waiting for a process to exit before reading its pipes deadlocks once either
+/// pipe crosses the kernel buffer size. The child blocks on write, never exits,
+/// and the caller only sees a timeout. Start this immediately after attaching
+/// pipes so output is consumed while the process is still running.
+enum ProcessPipeDrainer {
+    fileprivate final class LockedData: @unchecked Sendable {
+        private let lock = NSLock()
+        private var data = Data()
+
+        func set(_ value: Data) {
+            lock.lock()
+            data = value
+            lock.unlock()
+        }
+
+        func snapshot() -> Data {
+            lock.lock()
+            defer { lock.unlock() }
+            return data
+        }
+    }
+
+    struct Capture {
+        private let group: DispatchGroup
+        private let stdout: LockedData
+        private let stderr: LockedData
+
+        fileprivate init(group: DispatchGroup, stdout: LockedData, stderr: LockedData) {
+            self.group = group
+            self.stdout = stdout
+            self.stderr = stderr
+        }
+
+        func wait() -> (stdout: Data, stderr: Data) {
+            group.wait()
+            return (stdout.snapshot(), stderr.snapshot())
+        }
+    }
+
+    static func start(stdout stdoutHandle: FileHandle, stderr stderrHandle: FileHandle) -> Capture {
+        let group = DispatchGroup()
+        let stdout = LockedData()
+        let stderr = LockedData()
+
+        group.enter()
+        DispatchQueue.global(qos: .utility).async {
+            stdout.set((try? stdoutHandle.readToEnd()) ?? Data())
+            group.leave()
+        }
+
+        group.enter()
+        DispatchQueue.global(qos: .utility).async {
+            stderr.set((try? stderrHandle.readToEnd()) ?? Data())
+            group.leave()
+        }
+
+        return Capture(group: group, stdout: stdout, stderr: stderr)
+    }
+}
+#endif

--- a/scarf/Packages/ScarfCore/Sources/ScarfCore/Transport/SSHTransport.swift
+++ b/scarf/Packages/ScarfCore/Sources/ScarfCore/Transport/SSHTransport.swift
@@ -707,9 +707,19 @@ public struct SSHTransport: ServerTransport {
         proc.standardOutput = stdoutPipe
         proc.standardError = stderrPipe
         if stdin != nil { proc.standardInput = stdinPipe }
+        let pipeCapture = ProcessPipeDrainer.start(
+            stdout: stdoutPipe.fileHandleForReading,
+            stderr: stderrPipe.fileHandleForReading
+        )
         do {
             try proc.run()
         } catch {
+            try? stdoutPipe.fileHandleForWriting.close()
+            try? stderrPipe.fileHandleForWriting.close()
+            if stdin != nil {
+                try? stdinPipe.fileHandleForReading.close()
+            }
+            _ = pipeCapture.wait()
             throw TransportError.other(message: "Failed to launch \(executable): \(error.localizedDescription)")
         }
         // Parent's copy of the inherited ends — close so EOF lands when
@@ -746,20 +756,19 @@ public struct SSHTransport: ServerTransport {
                 // collect partial stdout. terminate() is async; without
                 // this wait the readToEnd below could race the close.
                 proc.waitUntilExit()
-                let partial = (try? stdoutPipe.fileHandleForReading.readToEnd()) ?? Data()
+                let captured = pipeCapture.wait()
                 try? stdoutPipe.fileHandleForReading.close()
                 try? stderrPipe.fileHandleForReading.close()
-                throw TransportError.timeout(seconds: timeout, partialStdout: partial)
+                throw TransportError.timeout(seconds: timeout, partialStdout: captured.stdout)
             }
         } else {
             proc.waitUntilExit()
         }
-        let out = (try? stdoutPipe.fileHandleForReading.readToEnd()) ?? Data()
-        let err = (try? stderrPipe.fileHandleForReading.readToEnd()) ?? Data()
+        let captured = pipeCapture.wait()
         try? stdoutPipe.fileHandleForReading.close()
         try? stderrPipe.fileHandleForReading.close()
         try? stdinPipe.fileHandleForWriting.close()
-        return ProcessResult(exitCode: proc.terminationStatus, stdout: out, stderr: err)
+        return ProcessResult(exitCode: proc.terminationStatus, stdout: captured.stdout, stderr: captured.stderr)
         #endif
     }
 }

--- a/scarf/Packages/ScarfCore/Tests/ScarfCoreTests/M0bTransportTests.swift
+++ b/scarf/Packages/ScarfCore/Tests/ScarfCoreTests/M0bTransportTests.swift
@@ -126,6 +126,32 @@ import Foundation
         #expect(explicit.contextID != ServerContext.local.id)
     }
 
+    @Test func localTransportRunProcessDrainsLargeStdoutAndStderr() throws {
+        let script = """
+        for i in $(seq 1 256); do
+            printf '%04d:' "$i"
+            printf '%.0sx' $(seq 1 1018)
+            printf '\\n'
+        done
+        for i in $(seq 1 256); do
+            printf '%04d:' "$i" >&2
+            printf '%.0sy' $(seq 1 1018) >&2
+            printf '\\n' >&2
+        done
+        """
+
+        let result = try LocalTransport().runProcess(
+            executable: "/bin/sh",
+            args: ["-c", script],
+            stdin: nil,
+            timeout: 10
+        )
+
+        #expect(result.exitCode == 0)
+        #expect(result.stdout.count >= 256 * 1024)
+        #expect(result.stderr.count >= 256 * 1024)
+    }
+
     @Test func sshTransportStaticPathsAreStable() {
         // controlDirPath() is used by Mac tests (`ControlPathTests`) to check
         // the macOS 104-byte sun_path limit. Pin the format here so the


### PR DESCRIPTION
## Summary

Fixes #94.

This fixes the Kanban timeout that can happen when Scarf reads a large Hermes task board over SSH. The Kanban path uses `transport.runProcess`; for SSH servers that reaches `SSHTransport.runLocal`, which previously waited for the child process to exit before reading stdout/stderr. When `hermes kanban list --json` emits enough JSON to fill the pipe buffer, the local `ssh` subprocess blocks on write, never exits, and Scarf reports a timeout.

The fix adds a shared `ProcessPipeDrainer` and uses it in both local and SSH `runProcess` implementations so stdout and stderr are drained while the subprocess is running.

## Changes

- Add `ProcessPipeDrainer` for concurrent stdout/stderr capture.
- Use it in `LocalTransport.runProcess`.
- Use it in `SSHTransport.runLocal`, which covers SSH-backed `runProcess` callers such as Kanban.
- Preserve partial stdout on timeout using already-drained output.
- Add a regression test that emits more than 256 KB to both stdout and stderr.

## Verification

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter localTransportRunProcessDrainsLargeStdoutAndStderr`
- `CI=1 DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./scripts/local-build.sh`

Manual verification against a real remote Hermes server:

- `ssh homelabUbuntu '/home/ubuntu/.local/bin/hermes kanban list --json'` returns a 795,258-byte payload.
- Payload contains 343 tasks: 3 todo, 23 blocked, 317 done.
- Launched the fixed macOS debug build and opened Kanban against the same server.
- Kanban rendered matching counts: UP NEXT 3, BLOCKED 23, DONE 317.
- Waited past the previous 20s timeout window; toolbar remained connected.
