### PR TITLE
fix: check hasMarkedText() before sending on return key (IME composition)

### DIFF
--- a/scarf/scarf/Features/Chat/Views/RichChatInputBar.swift
+++ b/scarf/scarf/Features/Chat/Views/RichChatInputBar.swift
@@ -203,6 +203,11 @@ struct RichChatInputBar: View {
                         if press.modifiers.contains(.shift) {
                             return .ignored
                         }
+                        // Allow IME composition to consume the return key first
+                        // (e.g. Chinese Pinyin candidate selection) — don't send.
+                        if hasMarkedText() {
+                            return .ignored
+                        }
                         if showMenu, let command = filteredCommands[safe: selectedIndex] {
                             insertCommand(command)
                             return .handled
@@ -366,6 +371,21 @@ struct RichChatInputBar: View {
         }
         .padding(ScarfSpace.s5)
         .frame(width: 380)
+    }
+
+    /// Returns true when an IME (input method editor) is actively composing text
+    /// — e.g. Chinese Pinyin with a candidate window still open. When true, the
+    /// return key should be ignored for sending so the IME can finish composition.
+    private func hasMarkedText() -> Bool {
+#if canImport(AppKit)
+        guard let window = NSApp.keyWindow,
+              let textView = window.firstResponder as? NSTextView else {
+            return false
+        }
+        return textView.hasMarkedText()
+#else
+        return false
+#endif
     }
 
     private var canSend: Bool {


### PR DESCRIPTION
## Problem

When using a Chinese IME (WeType, Sogou, Apple Pinyin) on macOS, pressing **Return** to select a candidate from the IME composition window accidentally **sends the message** instead of finishing composition.

## Root cause

`RichChatInputBar.swift` uses `.onKeyPress(.return, phases: .down)` which fires on key-down — before the IME has a chance to consume the Return key event for candidate selection. The handler immediately calls `send()` and returns `.handled`, preventing the IME from processing the key.

## Fix

1. Added `hasMarkedText()` helper that checks `NSTextView.hasMarkedText()` on the current first responder
2. In the `.onKeyPress(.return)` handler, return `.ignored` when `hasMarkedText()` is true, allowing the IME to consume the Return key for composition

### Before
```swift
.onKeyPress(.return, phases: .down) { press in
    if press.modifiers.contains(.shift) { return .ignored }
    if showMenu, let command = ... { ... }
    send()
    return .handled
}
```

### After
```swift
.onKeyPress(.return, phases: .down) { press in
    if press.modifiers.contains(.shift) { return .ignored }
    if hasMarkedText() { return .ignored }
    if showMenu, let command = ... { ... }
    send()
    return .handled
}
```

## Tested

- ✅ Chinese Pinyin (WeType): Return selects candidate, doesn't send
- ✅ No IME active: Return sends message normally  
- ✅ Shift+Return: inserts newline (unchanged)
- ✅ Slash command menu: Return selects command (unchanged)