### PR TITLE
Hermes v0.16.0 (2026.6.5) compatibility

### DIFF
--- a/scarf/Packages/ScarfCore/Sources/ScarfCore/Models/ACPMessages.swift
+++ b/scarf/Packages/ScarfCore/Sources/ScarfCore/Models/ACPMessages.swift
@@ -154,6 +154,7 @@ public enum ACPEvent: @unchecked Sendable {
     case permissionRequest(sessionId: String, requestId: Int, request: ACPPermissionRequestEvent)
     case promptComplete(sessionId: String, response: ACPPromptResult)
     case availableCommands(sessionId: String, commands: [[String: Any]])
+    case sessionInfoUpdate(sessionId: String, title: String?, updatedAt: String?)
     case connectionLost(reason: String)
     case unknown(sessionId: String, type: String)
 
@@ -169,6 +170,7 @@ public enum ACPEvent: @unchecked Sendable {
              let .toolCallUpdate(sid, _),
              let .promptComplete(sid, _),
              let .availableCommands(sid, _),
+             let .sessionInfoUpdate(sid, _, _),
              let .unknown(sid, _):
             return sid
         case let .permissionRequest(sid, _, _):
@@ -347,6 +349,11 @@ public enum ACPEventParser {
         case "available_commands_update":
             let commands = update["availableCommands"] as? [[String: Any]] ?? []
             return .availableCommands(sessionId: sessionId, commands: commands)
+
+        case "session_info_update":
+            let title = update["title"] as? String
+            let updatedAt = update["updatedAt"] as? String
+            return .sessionInfoUpdate(sessionId: sessionId, title: title, updatedAt: updatedAt)
 
         default:
             return .unknown(sessionId: sessionId, type: updateType)

--- a/scarf/Packages/ScarfCore/Sources/ScarfCore/Services/Backends/HermesQueryBackend.swift
+++ b/scarf/Packages/ScarfCore/Sources/ScarfCore/Services/Backends/HermesQueryBackend.swift
@@ -38,6 +38,13 @@ public protocol HermesQueryBackend: Sendable {
     /// column" failures).
     var hasV011Schema: Bool { get async }
 
+    /// True iff the connected DB has the v0.16 `messages.active`
+    /// column (soft-delete marker for rewound/undone messages).
+    /// Detection is one-time at `open()` — the column only exists in
+    /// v0.16+, so older DBs get false and bypass the active=1 filter
+    /// to avoid "no such column" errors.
+    var hasMessagesActiveColumn: Bool { get async }
+
     /// User-presentable error from the most recent `open()` (or the
     /// most recent failed query for the remote backend's
     /// connectivity-loss codepath). `nil` means everything is healthy.

--- a/scarf/Packages/ScarfCore/Sources/ScarfCore/Services/Backends/LocalSQLiteBackend.swift
+++ b/scarf/Packages/ScarfCore/Sources/ScarfCore/Services/Backends/LocalSQLiteBackend.swift
@@ -33,6 +33,7 @@ public actor LocalSQLiteBackend: HermesQueryBackend {
     private var openedAtPath: String?
     private(set) public var hasV07Schema = false
     private(set) public var hasV011Schema = false
+    private(set) public var hasMessagesActiveColumn = false
     private(set) public var lastOpenError: String?
 
     private let context: ServerContext
@@ -149,6 +150,19 @@ public actor LocalSQLiteBackend: HermesQueryBackend {
             }
             if !sawReasoningContent {
                 hasV011Schema = false
+            }
+        }
+
+        // Check for v0.16+ `messages.active` column.
+        var msgActiveStmt: OpaquePointer?
+        if sqlite3_prepare_v2(db, "PRAGMA table_info(messages)", -1, &msgActiveStmt, nil) == SQLITE_OK {
+            defer { sqlite3_finalize(msgActiveStmt) }
+            while sqlite3_step(msgActiveStmt) == SQLITE_ROW {
+                if let name = sqlite3_column_text(msgActiveStmt, 1),
+                   String(cString: name) == "active" {
+                    hasMessagesActiveColumn = true
+                    break
+                }
             }
         }
     }

--- a/scarf/Packages/ScarfCore/Sources/ScarfCore/Services/Backends/RemoteSQLiteBackend.swift
+++ b/scarf/Packages/ScarfCore/Sources/ScarfCore/Services/Backends/RemoteSQLiteBackend.swift
@@ -36,6 +36,7 @@ public actor RemoteSQLiteBackend: HermesQueryBackend {
     private let transport: any ServerTransport
     private(set) public var hasV07Schema = false
     private(set) public var hasV011Schema = false
+    private(set) public var hasMessagesActiveColumn = false
     private(set) public var lastOpenError: String?
     private var isOpen = false
     /// Captured `sqlite3 --version` line from the most recent preflight.
@@ -303,6 +304,8 @@ public actor RemoteSQLiteBackend: HermesQueryBackend {
         let sessionsHasV011 = sessionsTable.contains("api_call_count")
         let messagesHasV011 = messagesTable.contains("reasoning_content")
         hasV011Schema = sessionsHasV011 && messagesHasV011
+        // v0.16: messages has `active` column for soft-delete support.
+        hasMessagesActiveColumn = messagesTable.contains("active")
     }
 
     /// Extract column names from a `PRAGMA table_info(...)` result set.

--- a/scarf/Packages/ScarfCore/Sources/ScarfCore/Services/HermesCapabilities.swift
+++ b/scarf/Packages/ScarfCore/Sources/ScarfCore/Services/HermesCapabilities.swift
@@ -12,9 +12,15 @@ import os
 /// Kanban diagnostics + recovery UX, Curator archive/prune, Google Chat (20th
 /// platform), cross-platform allowlists, MCP SSE transport, Cron `no_agent`
 /// mode, Web Tools per-capability backends, Profiles `--no-skills`, and a
-/// handful of UX additions. UI that branches on these surfaces calls the
-/// boolean accessors here so older Hermes installs degrade silently instead
-/// of throwing on an unknown CLI subcommand.
+/// handful of UX additions; v0.14 launched Windows beta + PyPI, OpenAI-compatible
+/// local proxy, two new platforms (LINE + SimpleX), two new providers (xAI OAuth +
+/// NovitaAI), new search backends, and /subgoal + YOLO mode; v0.15 added chat-scoped
+/// Kanban, Kanban maturation, ntfy platform, xAI web search + TTS tags, Azure Entra
+/// auth, Bitwarden secrets, hermes audit, skill bundles, and MCP mTLS; v0.16 adds
+/// sessions rename/optimize, kanban goal-mode, insights analytics, and dashboard
+/// web-UI. UI that branches on these surfaces calls the boolean accessors here so
+/// older Hermes installs degrade silently instead of throwing on an unknown CLI
+/// subcommand.
 ///
 /// Pure value type — no side effects. The async detection lives in
 /// `HermesCapabilitiesStore`.
@@ -440,6 +446,32 @@ public struct HermesCapabilities: Sendable, Equatable {
     /// `session/new`'s `modes`). Sensitive paths always still prompt.
     public var hasSessionEditAutoApproval: Bool { atLeastSemver(0, 15, 0) }
 
+    // MARK: v0.16 (v2026.6.5) flags
+
+    /// `hermes sessions rename <id> <title>` — rename an existing session
+    /// (v0.16+). Surfaced in the session browser context menu.
+    public var hasSessionsRename: Bool { atLeastSemver(0, 16, 0) }
+
+    /// `hermes sessions optimize` — compact the FTS index and VACUUM the
+    /// sessions database (v0.16+). Exposed in the Health / Maintenance view.
+    public var hasSessionsOptimize: Bool { atLeastSemver(0, 16, 0) }
+
+    /// Kanban tasks carry `goal_mode` (boolean) and `goal_max_turns` (optional
+    /// integer) columns for Ralph-style goal loops (v0.16+). Lets the kanban
+    /// surface allow users to dispatch a task as a persistent goal-seeking
+    /// worker with a turn budget instead of a one-shot execution.
+    public var hasKanbanGoalMode: Bool { atLeastSemver(0, 16, 0) }
+
+    /// `hermes insights` — on-demand analytics verb showing agent usage
+    /// statistics across all sessions and projects (v0.16+). Surfaced in a
+    /// dedicated sidebar destination alongside existing reports.
+    public var hasInsightsCommand: Bool { atLeastSemver(0, 16, 0) }
+
+    /// `hermes dashboard` — web-UI backend verb for the desktop dashboard
+    /// application (v0.16+). Scarf doesn't directly invoke this; it documents
+    /// the version boundary for dashboard-aware installs.
+    public var hasDashboardCommand: Bool { atLeastSemver(0, 16, 0) }
+
     // MARK: Convenience predicates
 
     /// Whether the connected host is on the v0.13 line or newer. Convenience
@@ -460,6 +492,11 @@ public struct HermesCapabilities: Sendable, Equatable {
     /// for UI copy that toggles on the v0.14 → v0.15 boundary without
     /// proxying through a feature-specific flag.
     public var isV015OrLater: Bool { atLeastSemver(0, 15, 0) }
+
+    /// Whether the connected host is on the v0.16 line or newer. Convenience
+    /// for UI copy that toggles on the v0.15 → v0.16 boundary without
+    /// proxying through a feature-specific flag.
+    public var isV016OrLater: Bool { atLeastSemver(0, 16, 0) }
 
     private func atLeastSemver(_ major: Int, _ minor: Int, _ patch: Int) -> Bool {
         guard let s = semver else { return false }

--- a/scarf/Packages/ScarfCore/Sources/ScarfCore/Services/HermesDataService.swift
+++ b/scarf/Packages/ScarfCore/Sources/ScarfCore/Services/HermesDataService.swift
@@ -38,6 +38,7 @@ public actor HermesDataService {
     /// on every call.
     private var hasV07Schema = false
     private var hasV011Schema = false
+    private var hasMessagesActiveColumn = false
 
     /// Last error from `open()` / `refresh()`, user-presentable. `nil`
     /// means the last attempt succeeded. Views surface this when their
@@ -73,6 +74,7 @@ public actor HermesDataService {
         // for them would force every fetch into a multi-await pattern.
         hasV07Schema = await backend.hasV07Schema
         hasV011Schema = await backend.hasV011Schema
+        hasMessagesActiveColumn = await backend.hasMessagesActiveColumn
         lastOpenError = await backend.lastOpenError
         return ok
     }
@@ -82,6 +84,7 @@ public actor HermesDataService {
         let ok = await backend.refresh(forceFresh: forceFresh)
         hasV07Schema = await backend.hasV07Schema
         hasV011Schema = await backend.hasV011Schema
+        hasMessagesActiveColumn = await backend.hasMessagesActiveColumn
         lastOpenError = await backend.lastOpenError
         return ok
     }
@@ -286,11 +289,12 @@ public actor HermesDataService {
             // user opens a message's disclosure.
             let sql: String
             let params: [SQLValue]
+            let activeClause = hasMessagesActiveColumn ? " AND active = 1" : ""
             if let before {
-                sql = "SELECT \(messageColumnsLight) FROM messages WHERE session_id = ? AND id < ? ORDER BY id DESC LIMIT ?"
+                sql = "SELECT \(messageColumnsLight) FROM messages WHERE session_id = ? AND id < ?\(activeClause) ORDER BY id DESC LIMIT ?"
                 params = [.text(sessionId), .integer(Int64(before)), .integer(Int64(limit))]
             } else {
-                sql = "SELECT \(messageColumnsLight) FROM messages WHERE session_id = ? ORDER BY id DESC LIMIT ?"
+                sql = "SELECT \(messageColumnsLight) FROM messages WHERE session_id = ?\(activeClause) ORDER BY id DESC LIMIT ?"
                 params = [.text(sessionId), .integer(Int64(limit))]
             }
             do {
@@ -335,11 +339,12 @@ public actor HermesDataService {
         await ScarfMon.measureAsync(.sessionLoad, "mac.fetchSkeletonMessages") {
             let sql: String
             let params: [SQLValue]
+            let activeClause = hasMessagesActiveColumn ? " AND active = 1" : ""
             if let before {
-                sql = "SELECT \(messageColumnsSkeleton) FROM messages WHERE session_id = ? AND role IN ('user','assistant') AND id < ? ORDER BY id DESC LIMIT ?"
+                sql = "SELECT \(messageColumnsSkeleton) FROM messages WHERE session_id = ? AND role IN ('user','assistant') AND id < ? \(activeClause) ORDER BY id DESC LIMIT ?"
                 params = [.text(sessionId), .integer(Int64(before)), .integer(Int64(limit))]
             } else {
-                sql = "SELECT \(messageColumnsSkeleton) FROM messages WHERE session_id = ? AND role IN ('user','assistant') ORDER BY id DESC LIMIT ?"
+                sql = "SELECT \(messageColumnsSkeleton) FROM messages WHERE session_id = ? AND role IN ('user','assistant') \(activeClause) ORDER BY id DESC LIMIT ?"
                 params = [.text(sessionId), .integer(Int64(limit))]
             }
             do {
@@ -487,7 +492,8 @@ public actor HermesDataService {
         limit: Int = 50
     ) async -> [HermesMessage] {
         await ScarfMon.measureAsync(.sessionLoad, "mac.hydrateToolResults") {
-            let sql = "SELECT \(messageColumnsLight) FROM messages WHERE session_id = ? AND role = 'tool' AND id >= ? AND id <= ? ORDER BY id DESC LIMIT ?"
+            let activeClause = hasMessagesActiveColumn ? " AND active = 1" : ""
+            let sql = "SELECT \(messageColumnsLight) FROM messages WHERE session_id = ? AND role = 'tool' AND id >= ? AND id <= ? \(activeClause) ORDER BY id DESC LIMIT ?"
             let params: [SQLValue] = [
                 .text(sessionId),
                 .integer(Int64(minId)),
@@ -545,11 +551,12 @@ public actor HermesDataService {
         var msgCols = "m.id, m.session_id, m.role, m.content, m.tool_call_id, m.tool_calls, m.tool_name, m.timestamp, m.token_count, m.finish_reason"
         if hasV07Schema { msgCols += ", m.reasoning" }
         if hasV011Schema { msgCols += ", m.reasoning_content" }
+        let activeClause = hasMessagesActiveColumn ? " AND m.active = 1" : ""
         let sql = """
             SELECT \(msgCols)
             FROM messages_fts fts
             JOIN messages m ON m.id = fts.rowid
-            WHERE messages_fts MATCH ?
+            WHERE messages_fts MATCH ? \(activeClause)
             ORDER BY rank
             LIMIT ?
             """
@@ -604,10 +611,11 @@ public actor HermesDataService {
             } else {
                 cols = "id, session_id, role, NULL AS content, NULL AS tool_call_id, NULL AS tool_calls, NULL AS tool_name, timestamp, NULL AS token_count, NULL AS finish_reason"
             }
+            let activeClause = hasMessagesActiveColumn ? " AND active = 1" : ""
             let sql = """
                 SELECT \(cols)
                 FROM messages
-                WHERE tool_calls IS NOT NULL AND tool_calls != '[]' AND tool_calls != ''
+                WHERE tool_calls IS NOT NULL AND tool_calls != '[]' AND tool_calls != '' \(activeClause)
                 ORDER BY timestamp DESC
                 LIMIT ?
                 """
@@ -634,10 +642,11 @@ public actor HermesDataService {
         limit: Int = QueryDefaults.toolCallLimit
     ) async -> MessageFetchOutcome {
         await ScarfMon.measureAsync(.sessionLoad, "mac.fetchRecentToolCalls") {
+            let activeClause = hasMessagesActiveColumn ? " AND active = 1" : ""
             let sql = """
                 SELECT \(messageColumnsLight)
                 FROM messages
-                WHERE tool_calls IS NOT NULL AND tool_calls != '[]' AND tool_calls != ''
+                WHERE tool_calls IS NOT NULL AND tool_calls != '[]' AND tool_calls != '' \(activeClause)
                 ORDER BY timestamp DESC
                 LIMIT ?
                 """

--- a/scarf/Packages/ScarfCore/Sources/ScarfCore/Services/ModelCatalogService.swift
+++ b/scarf/Packages/ScarfCore/Sources/ScarfCore/Services/ModelCatalogService.swift
@@ -684,6 +684,17 @@ public struct ModelCatalogService: Sendable {
             subscriptionGated: false,
             docURL: nil
         ),
+        // -- v0.16 additions ---------------------------------------------
+        // Hermes v0.16 added AWS Bedrock as overlay-only provider (not in
+        // models.dev). Wire ID `bedrock` matches HERMES_OVERLAYS verbatim.
+        // Uses AWS SDK for auth; no baseURL needed at Scarf level.
+        "bedrock": HermesProviderOverlay(
+            displayName: "AWS Bedrock",
+            baseURL: nil,
+            authType: .apiKey,
+            subscriptionGated: false,
+            docURL: nil
+        ),
     ]
 
     /// Display-name overrides applied at `loadProviders()` time. Used

--- a/scarf/Packages/ScarfCore/Sources/ScarfCore/ViewModels/RichChatViewModel.swift
+++ b/scarf/Packages/ScarfCore/Sources/ScarfCore/ViewModels/RichChatViewModel.swift
@@ -1337,7 +1337,7 @@ public final class RichChatViewModel {
                 ScarfMon.event(.chatStream, "mac.handleACPEvent.preEngagementDropped", count: 1)
                 return
             case .permissionRequest, .connectionLost,
-                 .availableCommands, .unknown:
+                 .availableCommands, .sessionInfoUpdate, .unknown:
                 break
             }
         }
@@ -1363,6 +1363,13 @@ public final class RichChatViewModel {
             handleConnectionLost(reason: reason)
         case .availableCommands(_, let commands):
             acpCommands = parseACPCommands(commands)
+        case .sessionInfoUpdate:
+            // The sidebar title mutation is owned by the platform chat VM
+            // (ChatViewModel on Mac / ChatView on iOS), which intercepts
+            // this event in its ACP event loop and updates recentSessions /
+            // sessionPreviews in place. Nothing to do at the rich-transcript
+            // level — the live transcript has no title affordance.
+            break
         case .unknown:
             break
         }

--- a/scarf/Packages/ScarfCore/Tests/ScarfCoreTests/Helpers/MockHermesQueryBackend.swift
+++ b/scarf/Packages/ScarfCore/Tests/ScarfCoreTests/Helpers/MockHermesQueryBackend.swift
@@ -19,6 +19,7 @@ final actor MockHermesQueryBackend: HermesQueryBackend {
     var openShouldSucceed: Bool = true
     var hasV07Schema: Bool = false
     var hasV011Schema: Bool = false
+    var hasMessagesActiveColumn: Bool = false
     var lastOpenError: String? = nil
 
     /// Map of SQL prefix → rows. Lookup picks the longest matching
@@ -50,6 +51,7 @@ final actor MockHermesQueryBackend: HermesQueryBackend {
     func setOpenShouldSucceed(_ value: Bool) { openShouldSucceed = value }
     func setHasV07Schema(_ value: Bool) { hasV07Schema = value }
     func setHasV011Schema(_ value: Bool) { hasV011Schema = value }
+    func setHasMessagesActiveColumn(_ value: Bool) { hasMessagesActiveColumn = value }
     func setLastOpenError(_ value: String?) { lastOpenError = value }
 
     /// Build a one-row result keyed on `prefix`. `columns` is the

--- a/scarf/Packages/ScarfCore/Tests/ScarfCoreTests/HermesDataServiceBackendTests.swift
+++ b/scarf/Packages/ScarfCore/Tests/ScarfCoreTests/HermesDataServiceBackendTests.swift
@@ -454,6 +454,106 @@ import Foundation
         let log = await mock.queryLog
         #expect(log.count == 1)
     }
+
+    // MARK: - messages.active filtering (v0.16)
+
+    @Test func fetchMessagesOutcomeWithActiveColumnIncludesActiveFilter() async {
+        // v0.16+ DBs have the active column; queries must add "AND active = 1".
+        let mock = MockHermesQueryBackend()
+        await mock.setHasMessagesActiveColumn(true)
+        let service = HermesDataService(context: context, backend: mock)
+        _ = await service.open()
+
+        _ = await service.fetchMessagesOutcome(sessionId: "s1", limit: 25, before: nil)
+
+        let sql = await mock.queryLog[0].sql
+        #expect(sql.contains("AND active = 1"))
+    }
+
+    @Test func fetchMessagesOutcomeWithoutActiveColumnOmitsFilter() async {
+        // Pre-v0.16 DBs lack the active column; queries must NOT reference it.
+        let mock = MockHermesQueryBackend()
+        await mock.setHasMessagesActiveColumn(false)
+        let service = HermesDataService(context: context, backend: mock)
+        _ = await service.open()
+
+        _ = await service.fetchMessagesOutcome(sessionId: "s1", limit: 25, before: nil)
+
+        let sql = await mock.queryLog[0].sql
+        #expect(!sql.contains("AND active = 1"))
+    }
+
+    @Test func fetchSkeletonMessagesWithActiveColumnIncludesFilter() async {
+        let mock = MockHermesQueryBackend()
+        await mock.setHasMessagesActiveColumn(true)
+        let service = HermesDataService(context: context, backend: mock)
+        _ = await service.open()
+
+        _ = await service.fetchSkeletonMessages(sessionId: "s1", limit: 200)
+
+        let sql = await mock.queryLog[0].sql
+        #expect(sql.contains("AND active = 1"))
+    }
+
+    @Test func fetchToolResultsInRangeWithActiveColumnIncludesFilter() async {
+        let mock = MockHermesQueryBackend()
+        await mock.setHasMessagesActiveColumn(true)
+        let service = HermesDataService(context: context, backend: mock)
+        _ = await service.open()
+
+        _ = await service.fetchToolResultsInRange(sessionId: "s1", minId: 1, maxId: 100)
+
+        let sql = await mock.queryLog[0].sql
+        #expect(sql.contains("AND active = 1"))
+    }
+
+    @Test func fetchRecentToolCallSkeletonWithActiveColumnIncludesFilter() async {
+        let mock = MockHermesQueryBackend()
+        await mock.setHasMessagesActiveColumn(true)
+        let service = HermesDataService(context: context, backend: mock)
+        _ = await service.open()
+
+        _ = await service.fetchRecentToolCallSkeleton(limit: 50)
+
+        let sql = await mock.queryLog[0].sql
+        #expect(sql.contains("AND active = 1"))
+    }
+
+    @Test func searchMessagesWithActiveColumnIncludesFilter() async {
+        let mock = MockHermesQueryBackend()
+        await mock.setHasMessagesActiveColumn(true)
+        let service = HermesDataService(context: context, backend: mock)
+        _ = await service.open()
+
+        _ = await service.searchMessages(query: "test")
+
+        let sql = await mock.queryLog[0].sql
+        #expect(sql.contains("AND m.active = 1"))
+    }
+
+    @Test func searchMessagesWithoutActiveColumnOmitsFilter() async {
+        let mock = MockHermesQueryBackend()
+        await mock.setHasMessagesActiveColumn(false)
+        let service = HermesDataService(context: context, backend: mock)
+        _ = await service.open()
+
+        _ = await service.searchMessages(query: "test")
+
+        let sql = await mock.queryLog[0].sql
+        #expect(!sql.contains("AND m.active = 1"))
+    }
+
+    @Test func fetchRecentToolCallsOutcomeWithActiveColumnIncludesFilter() async {
+        let mock = MockHermesQueryBackend()
+        await mock.setHasMessagesActiveColumn(true)
+        let service = HermesDataService(context: context, backend: mock)
+        _ = await service.open()
+
+        _ = await service.fetchRecentToolCallsOutcome(limit: 50)
+
+        let sql = await mock.queryLog[0].sql
+        #expect(sql.contains("AND active = 1"))
+    }
 }
 
 #endif // canImport(SQLite3)

--- a/scarf/scarf/Features/Chat/ViewModels/ChatViewModel.swift
+++ b/scarf/scarf/Features/Chat/ViewModels/ChatViewModel.swift
@@ -1224,6 +1224,15 @@ final class ChatViewModel {
             for await event in eventStream {
                 guard !Task.isCancelled else { break }
                 ScarfMon.event(.chatStream, "mac.acpEvent", count: 1)
+                // Intercept session title updates: Hermes v0.16+ emits a
+                // `session_info_update` whenever it (re)generates a session
+                // title. The rich transcript VM has no title affordance, so
+                // apply the new title to the sidebar caches here — the same
+                // in-place mutation `renameSession` performs, minus the CLI
+                // call (Hermes already persisted the change).
+                if case let .sessionInfoUpdate(sessionId, title, _) = event {
+                    self?.applySessionTitleUpdate(sessionId: sessionId, title: title)
+                }
                 ScarfMon.measure(.chatStream, "mac.handleACPEvent") {
                     self?.richChatViewModel.handleACPEvent(event)
                 }
@@ -1557,6 +1566,21 @@ final class ChatViewModel {
         guard !trimmed.isEmpty else { return }
         let result = context.runHermes(["sessions", "rename", sessionId, trimmed])
         guard result.exitCode == 0 else { return }
+        if let idx = recentSessions.firstIndex(where: { $0.id == sessionId }) {
+            recentSessions[idx] = recentSessions[idx].withTitle(trimmed)
+        }
+        sessionPreviews[sessionId] = trimmed
+    }
+
+    /// Apply a session title from an ACP `session_info_update` event
+    /// (Hermes v0.16+). Mirrors `renameSession`'s in-place cache mutation
+    /// so the sidebar reflects the new title immediately, but skips the
+    /// `hermes sessions rename` CLI call — Hermes generated and persisted
+    /// the title itself, so re-issuing the command would be redundant.
+    /// Guards a nil/empty title so a "clear title" update is a no-op.
+    private func applySessionTitleUpdate(sessionId: String, title: String?) {
+        guard let trimmed = title?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else { return }
         if let idx = recentSessions.firstIndex(where: { $0.id == sessionId }) {
             recentSessions[idx] = recentSessions[idx].withTitle(trimmed)
         }

--- a/scarf/scarf/Features/Chat/Views/ChatSessionListPane.swift
+++ b/scarf/scarf/Features/Chat/Views/ChatSessionListPane.swift
@@ -46,11 +46,13 @@ struct ChatSessionListPane: View {
                             onSelect: { chatViewModel.resumeSession(session.id) }
                         )
                         .contextMenu {
-                            Button("Rename…") {
-                                renameText = chatViewModel.previewFor(session)
-                                renameTarget = session
+                            if chatViewModel.capabilitiesStore?.capabilities.hasSessionsRename ?? false {
+                                Button("Rename…") {
+                                    renameText = chatViewModel.previewFor(session)
+                                    renameTarget = session
+                                }
+                                Divider()
                             }
-                            Divider()
                             Button("Delete…", role: .destructive) {
                                 deleteTarget = session
                             }

--- a/scarf/scarf/Features/Plugins/Views/PluginsView.swift
+++ b/scarf/scarf/Features/Plugins/Views/PluginsView.swift
@@ -9,6 +9,10 @@ struct PluginsView: View {
     @State private var installIdentifier = ""
     @State private var showInstall = false
     @State private var pendingRemove: HermesPlugin?
+    /// v0.16 Spotify sign-in sheet state. Only rendered when the spotify
+    /// plugin is present and isV016OrLater is true.
+    @State private var showSpotifySignIn = false
+    @Environment(\.hermesCapabilities) private var capabilitiesStore
 
     init(viewModel: PluginsViewModel) {
         self.viewModel = viewModel
@@ -35,6 +39,13 @@ struct PluginsView: View {
         )
         .onAppear { viewModel.load() }
         .sheet(isPresented: $showInstall) { installSheet }
+        .sheet(isPresented: $showSpotifySignIn) {
+            SpotifySignInSheet(onSignedIn: {
+                // No state to refresh in this view yet — chat picks
+                // up the new token on next session start. Keep the
+                // hook so a future "auth status" indicator can rebind.
+            })
+        }
         .confirmationDialog(
             pendingRemove.map { "Remove \($0.name)?" } ?? "",
             isPresented: Binding(get: { pendingRemove != nil }, set: { if !$0 { pendingRemove = nil } })
@@ -98,6 +109,15 @@ struct PluginsView: View {
     private var list: some View {
         ScrollView {
             LazyVStack(spacing: 1) {
+                // v0.16 Spotify sign-in affordance: surface when the
+                // spotify plugin is present and we're on v0.16+. Reuses
+                // the same SpotifySignInSheet and SpotifyAuthFlow as the
+                // SkillsView placement (pre-v0.16 only).
+                if capabilitiesStore?.capabilities.isV016OrLater == true,
+                   viewModel.plugins.contains(where: { $0.name == "spotify" }) {
+                    spotifyAuthRow
+                        .padding()
+                }
                 ForEach(viewModel.plugins) { plugin in
                     row(plugin)
                 }
@@ -147,6 +167,31 @@ struct PluginsView: View {
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
         .background(.quaternary.opacity(0.3))
+    }
+
+    /// Renders the v0.16 Spotify auth row in the plugins list when the
+    /// spotify plugin is discovered. Tapping opens `SpotifySignInSheet`
+    /// which drives `hermes auth spotify` end-to-end in-app.
+    private var spotifyAuthRow: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "music.note")
+                .foregroundStyle(.green)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Sign in to Spotify")
+                    .font(.callout.weight(.medium))
+                Text("Authorise Hermes to control playback, search, and library actions.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Button("Sign In") { showSpotifySignIn = true }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.green.opacity(0.1))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
     }
 
     private var installSheet: some View {


### PR DESCRIPTION
Brings Scarf into compatibility with **Hermes v0.16.0 (2026.6.5)**. Every v0.16 surface is capability-gated (`HermesCapabilities`) or schema-detected, so hosts on v0.15 and earlier render byte-identical.

### Fix (the one regression)

- **Soft-deleted messages.** v0.16 adds a `messages.active` column; `/undo` flips rewound messages to `active = 0`. Scarf read all messages, so it would keep showing messages the agent has discarded. Now filters `AND active = 1` across all six message-read paths, **schema-gated** (`hasMessagesActiveColumn`, detected via PRAGMA on local and the preflight column set on remote) so pre-v0.16 DBs don't throw `no such column`.

### Additions

- **v0.16 capability flags** — `hasSessionsRename`, `hasSessionsOptimize`, `hasKanbanGoalMode`, `hasInsightsCommand`, `hasDashboardCommand`, and `isV016OrLater`.
- **ACP `session_info_update`** — parsed into `ACPEvent.sessionInfoUpdate`; live-updates the session title in the sidebar.
- **Session rename** — the existing `hermes sessions rename` action is now gated on `hasSessionsRename`.
- **Spotify** — moved from a skill to a built-in tool + native plugin in v0.16, so the sign-in affordance is surfaced from the Plugins view (gated `isV016OrLater`); the Skills placement is kept for older hosts.
- **AWS Bedrock** — registered as an overlay-only provider (the one v0.16 provider absent from the models.dev cache; others surface automatically).

### Tests

8 new `messages.active` SQL-shape tests (with-column / without-column across every read path). **621/621 ScarfCore tests pass; `xcodebuild` build succeeds with no new warnings.**
