### PR TITLE
Hermes v0.16 wire-mismatch fixes (gateway + non-critical)

### DIFF
--- a/.memory/integration/hermes-v0-16-wire-verification-results-ws-audit.md
+++ b/.memory/integration/hermes-v0-16-wire-verification-results-ws-audit.md
@@ -12,6 +12,8 @@ tags:
 
 Verified the WS-* "verify against a live host" audit TODOs against the live Hermes v0.16 source (`~/.hermes/hermes-agent`, 2026.6.5) on 2026-06-14. Summary below; verified TODOs were dropped, mismatches captured as follow-up work.
 
+> **UPDATE 2026-06-15 — ALL MISMATCHES RESOLVED** on branch `fix/v016-mismatches` (commits `9bc39b7` gateway allowlist-path + gateway-list text parsing; `6786e66` kanban `verify` verb, curator `list-archived --json`, `openrouter.response_cache` scalar, `addMCPServerSSE` → `--url`+YAML, ACP `/goal`/`/subgoal` de-advertised). Each was re-verified against live v0.16 before fixing. The "MISMATCHES" notes below are kept for the audit trail.
+
 ## VERIFIED (assumption matches v0.16 — TODOs dropped)
 - ACP `/queue <text>` and `/steer <text>` ARE advertised + handled by the ACP adapter (server.py `_ADVERTISED_COMMANDS`).
 - `tts.xai.voice_id` and `tts.xai.auto_speech_tags` are the real xAI TTS keys (tools/tts_tool.py).

--- a/scarf/Packages/ScarfCore/Sources/ScarfCore/Models/GatewayAllowlistKind.swift
+++ b/scarf/Packages/ScarfCore/Sources/ScarfCore/Models/GatewayAllowlistKind.swift
@@ -5,8 +5,8 @@ import Foundation
 /// depending on the platform's primary noun for "addressable destination":
 ///
 /// - **`allowed_channels`** — Slack, Mattermost, Google Chat
-/// - **`allowed_chats`** — Telegram, WhatsApp
-/// - **`allowed_rooms`** — Matrix, DingTalk
+/// - **`allowed_chats`** — Telegram, WhatsApp, DingTalk
+/// - **`allowed_rooms`** — Matrix
 ///
 /// `GatewayAllowlistKind` encodes the (platform → key) mapping plus a few
 /// presentation hints (placeholder strings, singular noun) so the allowlist
@@ -17,7 +17,7 @@ public enum GatewayAllowlistKind: String, Sendable, Equatable {
     case chats      // -> allowed_chats
     case rooms      // -> allowed_rooms
 
-    /// YAML scalar key segment under `gateway.platforms.<platform>.<key>`.
+    /// YAML scalar key segment under top-level `<platform>.<key>`.
     public var yamlKey: String {
         switch self {
         case .channels: return "allowed_channels"
@@ -68,8 +68,8 @@ public enum GatewayAllowlistKind: String, Sendable, Equatable {
     public static func kind(for platform: String) -> GatewayAllowlistKind? {
         switch platform {
         case "slack", "mattermost", "google-chat", "googlechat": return .channels
-        case "telegram", "whatsapp":                              return .chats
-        case "matrix", "dingtalk":                                return .rooms
+        case "telegram", "whatsapp", "dingtalk":                  return .chats
+        case "matrix":                                            return .rooms
         default: return nil
         }
     }

--- a/scarf/Packages/ScarfCore/Sources/ScarfCore/Parsing/HermesConfig+YAML.swift
+++ b/scarf/Packages/ScarfCore/Sources/ScarfCore/Parsing/HermesConfig+YAML.swift
@@ -264,19 +264,15 @@ public extension HermesConfig {
         )
 
         // -- v0.13: per-platform Messaging Gateway settings --------------
-        // Read `gateway.platforms.<platform>.{allowed_channels|allowed_chats|
-        // allowed_rooms|busy_ack_enabled|gateway_restart_notification|
-        // slash_command_notice_ttl_seconds}` and bundle each platform that
-        // has at least one v0.13 key present in the file. Platforms without
-        // an explicit block don't appear in the dictionary, so the
-        // editor's `?? .empty` fallback hands the user the v0.13 defaults
-        // without leaving stale keys littered across the YAML.
-        //
-        // TODO(WS-5-Q2): the `gateway.platforms.*` path is unverified —
-        // Hermes v0.13 may emit allowlists under `platforms.<platform>.*`
-        // (sibling to existing `platforms.slack.reply_to_mode`) instead.
-        // If so, swap the `prefix` line below to `"platforms.\(platform)."`
-        // and update `GatewayConfigWriter` in lockstep.
+        // Allowlists live at top-level `<platform>.allowed_*` (verified
+        // v0.16): `slack.allowed_channels`, `telegram.allowed_chats`,
+        // `matrix.allowed_rooms`, `dingtalk.allowed_chats`, plus the
+        // top-level `<platform>.gateway_restart_notification` toggle.
+        // `busy_ack_enabled` / `slash_command_notice_ttl_seconds` are
+        // no-ops in v0.16 but kept for round-trip. Platforms without an
+        // explicit block don't appear in the dictionary, so the editor's
+        // `?? .empty` fallback hands the user the defaults without leaving
+        // stale keys littered across the YAML.
         let gatewayAllowlistPlatforms = [
             "slack", "mattermost", "google-chat",
             "telegram", "whatsapp",
@@ -284,7 +280,7 @@ public extension HermesConfig {
         ]
         var gatewayPlatforms: [String: GatewayPlatformSettings] = [:]
         for platform in gatewayAllowlistPlatforms {
-            let prefix = "gateway.platforms.\(platform)."
+            let prefix = "\(platform)."
             let allowedChannels = lists[prefix + "allowed_channels"] ?? []
             let allowedChats    = lists[prefix + "allowed_chats"]    ?? []
             let allowedRooms    = lists[prefix + "allowed_rooms"]    ?? []

--- a/scarf/Packages/ScarfCore/Sources/ScarfCore/Parsing/HermesConfig+YAML.swift
+++ b/scarf/Packages/ScarfCore/Sources/ScarfCore/Parsing/HermesConfig+YAML.swift
@@ -373,16 +373,17 @@ public extension HermesConfig {
             runtimeMetadataFooter: bool("agent.runtime_metadata_footer", default: false),
             gatewayPlatforms: gatewayPlatforms,
             // -- v0.13 additions -------------------------------------
-            // TODO(WS-6-Q1): the `openrouter.response_cache.enabled`
-            // key shape is provisional pending verification against a
-            // v0.13 `hermes config check`. If upstream uses a different
-            // path (e.g. `providers.openrouter.response_cache_enabled`
-            // or nested under `prompt_caching`), update this single
-            // line + the matching `setSetting` key in
-            // `SettingsViewModel.setOpenRouterResponseCache`. Default
-            // is `false` per WS-6-plan §Open Questions #2.
+            // Hermes v0.16: `openrouter.response_cache` is a SCALAR bool
+            // directly under `openrouter:` (default `true` in Hermes).
+            // Read it as the scalar. A legacy nested value
+            // (`openrouter.response_cache.enabled: …`) flattens to a
+            // different dotted key, so it has no scalar entry here and
+            // decodes to the default `false` — the next save writes the
+            // scalar, healing the shape. Keep in lockstep with the
+            // matching `setSetting` key in
+            // `SettingsViewModel.setOpenRouterResponseCache`.
             imageGenModel: str("image_gen.model", default: ""),
-            openrouterResponseCacheEnabled: bool("openrouter.response_cache.enabled", default: false),
+            openrouterResponseCacheEnabled: bool("openrouter.response_cache", default: false),
             // Pre-v0.13 hosts wrote a single `web_tools.backend`. v0.13 split
             // it into per-capability keys. Read all three so the round-trip
             // never loses a value the user already set; the WebTools tab

--- a/scarf/Packages/ScarfCore/Sources/ScarfCore/Services/CuratorService.swift
+++ b/scarf/Packages/ScarfCore/Sources/ScarfCore/Services/CuratorService.swift
@@ -45,46 +45,18 @@ public actor CuratorService {
         }.value
     }
 
-    /// `hermes curator list-archived [--json]`. Prefers JSON; falls back
-    /// to a defensive text parser. Empty / "no archived skills" sentinel
-    /// folds to `[]`.
+    /// `hermes curator list-archived`. Hermes has no `--json` flag on
+    /// this verb (re-verified against v0.16 — it prints text), so we
+    /// parse the text output directly. Empty / "no archived skills"
+    /// sentinel folds to `[]`.
     public func listArchived() async throws -> [HermesCuratorArchivedSkill] {
-        // TODO(WS-4-Q2): confirm `--json` is supported on v0.13
-        // `list-archived`. If not, drop the flag and rely on the text
-        // parser path. Until then we pass `--json` and parse the output
-        // tolerantly.
-        let args = ["curator", "list-archived", "--json"]
-        let (code, stdout, stderr) = await runHermes(args: args, timeout: 30)
-
-        // If --json isn't recognized, the CLI typically emits
-        // "unrecognized arguments: --json" or similar to stderr and
-        // exits non-zero. Retry without the flag and parse text.
-        if code != 0 {
-            let lower = (stderr + stdout).lowercased()
-            if lower.contains("unrecognized") || lower.contains("unknown") || lower.contains("no such option") {
-                let (c2, out2, err2) = await runHermes(args: ["curator", "list-archived"], timeout: 30)
-                try ensureSuccess(code: c2, stdout: out2, stderr: err2, verb: "list-archived")
-                return Self.parseListArchivedText(out2)
-            }
-            try ensureSuccess(code: code, stdout: stdout, stderr: stderr, verb: "list-archived")
-        }
+        let (code, stdout, stderr) = await runHermes(args: ["curator", "list-archived"], timeout: 30)
+        try ensureSuccess(code: code, stdout: stdout, stderr: stderr, verb: "list-archived")
 
         let trimmed = stdout.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.isEmpty || trimmed.lowercased().contains("no archived skills") {
             return []
         }
-        // Try JSON first — may also be a text dump if Hermes ignored `--json`.
-        if let data = trimmed.data(using: .utf8),
-           let arr = try? JSONDecoder().decode([HermesCuratorArchivedSkill].self, from: data) {
-            return arr
-        }
-        // Some builds wrap in `{"archived": [...]}` envelope.
-        struct Wrapper: Decodable { let archived: [HermesCuratorArchivedSkill] }
-        if let data = trimmed.data(using: .utf8),
-           let wrapped = try? JSONDecoder().decode(Wrapper.self, from: data) {
-            return wrapped.archived
-        }
-        // Text fallback — defensive parse.
         return Self.parseListArchivedText(stdout)
     }
 

--- a/scarf/Packages/ScarfCore/Sources/ScarfCore/Services/GatewayConfigWriter.swift
+++ b/scarf/Packages/ScarfCore/Sources/ScarfCore/Services/GatewayConfigWriter.swift
@@ -1,10 +1,12 @@
 import Foundation
 
-/// Direct YAML editor for `gateway.platforms.<platform>.allowed_<kind>:` list
-/// blocks. Hermes v0.13 added these list-valued keys, but `hermes config set`
-/// stringifies arrays (the same gotcha that forced Home Assistant's watch
-/// lists to stay read-only). The Messaging Gateway editor sidesteps the CLI
-/// for these keys by editing `~/.hermes/config.yaml` directly.
+/// Direct YAML editor for top-level `<platform>.allowed_<kind>:` list blocks.
+/// Hermes v0.16 reads gateway allowlists from top-level platform sections
+/// (`slack.allowed_channels`, `telegram.allowed_chats`, …) — NOT from
+/// `gateway.platforms.<platform>.*`. `hermes config set` stringifies arrays
+/// (the same gotcha that forced Home Assistant's watch lists to stay
+/// read-only), so the Messaging Gateway editor sidesteps the CLI for these
+/// keys by editing `~/.hermes/config.yaml` directly.
 ///
 /// **Pure-function `setList`** is the heart of the editor — it splits the
 /// YAML into lines, finds (or creates) the targeted block, and splices the
@@ -12,6 +14,12 @@ import Foundation
 /// `saveList` wrapper wires it through `ServerContext.readText` /
 /// `writeText`, so the same code path works on `.local` and `.ssh` servers
 /// — local goes through `LocalTransport`, remote round-trips via SCP.
+///
+/// **Merge, don't clobber.** When the top-level `<platform>:` section already
+/// exists (e.g. it holds `slack.reply_to_mode` or `busy_ack_enabled`), the
+/// allowlist key is spliced in alongside its siblings, which stay
+/// byte-for-byte. Only when the section is entirely absent do we append a
+/// fresh `<platform>:` scaffold.
 ///
 /// **Scalar fields don't go through here.** `busy_ack_enabled`,
 /// `gateway_restart_notification`, and `slash_command_notice_ttl_seconds`
@@ -26,20 +34,20 @@ import Foundation
 /// the full grammar — only "find this block, replace it, preserve the rest".
 public enum GatewayConfigWriter {
 
-    /// Insert or replace `gateway.platforms.<platform>.<key>:` block in the
-    /// YAML, preserving everything else byte-for-byte.
+    /// Insert or replace the top-level `<platform>.<key>:` block in the YAML,
+    /// preserving everything else byte-for-byte.
     ///
     /// - When `items` is empty, the block (and only the block — siblings
     ///   stay) is removed from the YAML if present, and the function is a
     ///   no-op if the block was already absent.
-    /// - When the block is absent and `items` is non-empty, the function
-    ///   appends a `gateway:` / `platforms:` / `<platform>:` scaffold at
-    ///   the end of the file, creating any missing ancestors. This keeps
-    ///   the function idempotent on round-trip but means the new block is
-    ///   appended rather than spliced into an existing top-level
-    ///   `gateway:` section. (See WS-5 plan §Notes for the trade-off; the
-    ///   alternative would mean reflowing existing siblings, which is the
-    ///   exact opposite of "preserve the surrounding YAML byte-for-byte".)
+    /// - When the top-level `<platform>:` section exists but the `<key>:`
+    ///   leaf is missing, the new block is spliced into the existing section
+    ///   alongside any sibling keys (which stay byte-for-byte).
+    /// - When the `<platform>:` section is absent and `items` is non-empty,
+    ///   the function appends a `<platform>:` scaffold at the end of the
+    ///   file. This keeps the function idempotent on round-trip but means
+    ///   the new block is appended rather than spliced into the middle of
+    ///   the file — preserving the surrounding YAML byte-for-byte.
     /// - When the block is present, its bullet rows are replaced with the
     ///   new items at the same indent. Items containing YAML-special
     ///   characters (`:` `#` `@` or leading whitespace) are single-quoted
@@ -50,15 +58,13 @@ public enum GatewayConfigWriter {
         key: String,
         items: [String]
     ) -> String {
-        let blockIndent = 6  // `gateway:\n  platforms:\n    <platform>:\n      <key>:`
-        let itemIndent = 8
+        let keyIndent = 2   // `<platform>:\n  <key>:`
+        let itemIndent = 4  // `<platform>:\n  <key>:\n    - item`
 
         let lines = yaml.components(separatedBy: "\n")
         let trimmedItems = items.filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
 
-        // Locate `      <key>:` whose lineage is gateway → platforms → <platform>.
-        // We find the start of the gateway block, walk down the indent tree, and
-        // bail out if any ancestor is missing.
+        // Locate `  <key>:` whose parent is the top-level `<platform>:` section.
         let location = locateBlock(
             in: lines,
             platform: platform,
@@ -72,7 +78,7 @@ public enum GatewayConfigWriter {
                 blockRange: blockRange,
                 key: key,
                 items: trimmedItems,
-                blockIndent: blockIndent,
+                keyIndent: keyIndent,
                 itemIndent: itemIndent
             )
         case .platformPresentKeyMissing(let insertAfter):
@@ -85,9 +91,10 @@ public enum GatewayConfigWriter {
                 insertAfterLineIndex: insertAfter,
                 key: key,
                 items: trimmedItems,
+                keyIndent: keyIndent,
                 itemIndent: itemIndent
             )
-        case .ancestorMissing:
+        case .platformMissing:
             if trimmedItems.isEmpty {
                 // Nothing to write, no existing block.
                 return yaml
@@ -130,15 +137,15 @@ public enum GatewayConfigWriter {
         /// rows attributed to it. Replacing this slice with the new block
         /// completes the edit.
         case found(ClosedRange<Int>)
-        /// `gateway → platforms → <platform>` exists, but the leaf `<key>:`
+        /// The top-level `<platform>:` section exists, but the leaf `<key>:`
         /// is absent under it. The associated value is the line index after
         /// which the new key should be inserted (last line in the platform's
         /// block, or the platform header itself if the platform's body is
         /// empty).
         case platformPresentKeyMissing(insertAfter: Int)
-        /// One of the ancestor section headers is missing. The whole
+        /// The top-level `<platform>:` section is missing entirely. The whole
         /// scaffold needs to be appended.
-        case ancestorMissing
+        case platformMissing
     }
 
     private static func locateBlock(
@@ -146,32 +153,16 @@ public enum GatewayConfigWriter {
         platform: String,
         key: String
     ) -> BlockLocation {
-        // Walk top-to-bottom looking for `gateway:` at indent 0.
-        guard let gatewayIdx = firstIndex(of: lines, headerLineEqualTo: "gateway:", indent: 0) else {
-            return .ancestorMissing
-        }
-        // Inside `gateway:`, find `  platforms:` at indent 2.
-        guard let platformsIdx = firstIndex(
-            of: lines,
-            after: gatewayIdx,
-            headerLineEqualTo: "platforms:",
-            indent: 2,
-            stopWhenIndentLessThan: 2
-        ) else {
-            return .ancestorMissing
-        }
-        // Inside `platforms:`, find `    <platform>:` at indent 4.
+        // Walk top-to-bottom looking for `<platform>:` at indent 0.
         guard let platformIdx = firstIndex(
             of: lines,
-            after: platformsIdx,
             headerLineEqualTo: "\(platform):",
-            indent: 4,
-            stopWhenIndentLessThan: 4
+            indent: 0
         ) else {
-            return .ancestorMissing
+            return .platformMissing
         }
 
-        // Inside the platform block, find `<key>:` at indent 6, OR the end
+        // Inside the platform block, find `<key>:` at indent 2, OR the end
         // of the platform's body if the key is missing.
         var keyIdx: Int?
         var lastBodyIdx = platformIdx
@@ -184,11 +175,11 @@ public enum GatewayConfigWriter {
                 i += 1
                 continue
             }
-            if indent < 6 {
-                // Out of the platform's block.
+            if indent < 2 {
+                // Out of the platform's block (next top-level section).
                 break
             }
-            if indent == 6 && trimmed == "\(key):" {
+            if indent == 2 && trimmed == "\(key):" {
                 keyIdx = i
                 break
             }
@@ -201,7 +192,7 @@ public enum GatewayConfigWriter {
         }
 
         // Walk down the bullet rows until we leave the block (indent shrinks
-        // below the bullet indent OR we hit a sibling key at indent 6).
+        // below the bullet indent OR we hit a sibling key at indent 2).
         var endIdx = keyIdx
         var j = keyIdx + 1
         while j < lines.count {
@@ -213,19 +204,19 @@ public enum GatewayConfigWriter {
             }
             let indent = leadingSpaces(line)
             // Block-style YAML allows bullets at the same indent as their
-            // parent key; tolerate 6-space `- item` rows alongside the
-            // canonical 8-space ones.
+            // parent key; tolerate 2-space `- item` rows alongside the
+            // canonical 4-space ones.
             let isBullet = trimmed.hasPrefix("- ")
-            if isBullet && (indent == 8 || indent == 6) {
+            if isBullet && (indent == 4 || indent == 2) {
                 endIdx = j
                 j += 1
                 continue
             }
-            // Anything not a bullet at indent ≥ 8 ends the block.
-            if indent <= 6 {
+            // Anything not a bullet at indent ≤ 2 ends the block.
+            if indent <= 2 {
                 break
             }
-            // Indent > 8 with no bullet — unusual but tolerate (e.g. inline
+            // Indent > 4 with no bullet — unusual but tolerate (e.g. inline
             // continuation). Treat as still in the block and advance.
             endIdx = j
             j += 1
@@ -239,12 +230,12 @@ public enum GatewayConfigWriter {
         blockRange: ClosedRange<Int>,
         key: String,
         items: [String],
-        blockIndent: Int,
+        keyIndent: Int,
         itemIndent: Int
     ) -> String {
         var newLines = Array(lines.prefix(blockRange.lowerBound))
         if !items.isEmpty {
-            newLines.append("\(spaces(blockIndent))\(key):")
+            newLines.append("\(spaces(keyIndent))\(key):")
             for item in items {
                 newLines.append("\(spaces(itemIndent))- \(yamlQuoteIfNeeded(item))")
             }
@@ -262,10 +253,11 @@ public enum GatewayConfigWriter {
         insertAfterLineIndex: Int,
         key: String,
         items: [String],
+        keyIndent: Int,
         itemIndent: Int
     ) -> String {
         var newLines = Array(lines.prefix(insertAfterLineIndex + 1))
-        newLines.append("      \(key):")
+        newLines.append("\(spaces(keyIndent))\(key):")
         for item in items {
             newLines.append("\(spaces(itemIndent))- \(yamlQuoteIfNeeded(item))")
         }
@@ -294,12 +286,10 @@ public enum GatewayConfigWriter {
         if !trimmed.isEmpty {
             lines.append("")  // blank separator
         }
-        lines.append("gateway:")
-        lines.append("  platforms:")
-        lines.append("    \(platform):")
-        lines.append("      \(key):")
+        lines.append("\(platform):")
+        lines.append("  \(key):")
         for item in items {
-            lines.append("        - \(yamlQuoteIfNeeded(item))")
+            lines.append("    - \(yamlQuoteIfNeeded(item))")
         }
         lines.append("")  // trailing newline so subsequent edits append cleanly
         return trimmed + lines.joined(separator: "\n")
@@ -329,35 +319,6 @@ public enum GatewayConfigWriter {
             if leadingSpaces(line) == indent && trimmed == header {
                 return i
             }
-        }
-        return nil
-    }
-
-    /// Scoped variant: search starts at `after + 1`, stops if a line at indent
-    /// `< stopWhenIndentLessThan` is encountered (we've left the parent block).
-    private static func firstIndex(
-        of lines: [String],
-        after: Int,
-        headerLineEqualTo header: String,
-        indent: Int,
-        stopWhenIndentLessThan: Int
-    ) -> Int? {
-        var i = after + 1
-        while i < lines.count {
-            let line = lines[i]
-            let trimmed = line.trimmingCharacters(in: .whitespaces)
-            if trimmed.isEmpty || trimmed.hasPrefix("#") {
-                i += 1
-                continue
-            }
-            let lineIndent = leadingSpaces(line)
-            if lineIndent < stopWhenIndentLessThan {
-                return nil
-            }
-            if lineIndent == indent && trimmed == header {
-                return i
-            }
-            i += 1
         }
         return nil
     }

--- a/scarf/Packages/ScarfCore/Sources/ScarfCore/Services/HermesGatewayListService.swift
+++ b/scarf/Packages/ScarfCore/Sources/ScarfCore/Services/HermesGatewayListService.swift
@@ -1,15 +1,15 @@
 import Foundation
 
-/// Cross-profile snapshot returned by `hermes gateway list --json` (Hermes
-/// v0.13+). Each profile is one configured Messaging Gateway instance — most
-/// users have a single `default` profile, but power users keep separate
-/// profiles for work / personal / project-specific accounts.
+/// Cross-profile snapshot derived from `hermes gateway list` (Hermes v0.16).
+/// Each profile is one configured Messaging Gateway instance — most users
+/// have a single `default` profile, but power users keep separate profiles
+/// for work / personal / project-specific accounts.
 public struct GatewayListSnapshot: Sendable, Equatable {
     public struct ProfileEntry: Sendable, Equatable {
         public let profile: String
         public let isRunning: Bool
         public let pid: Int?
-        public let platforms: [String]   // platform names connected/configured
+        public let platforms: [String]   // always empty: text output omits it
 
         public init(
             profile: String,
@@ -65,85 +65,100 @@ public struct GatewayListSnapshot: Sendable, Equatable {
     }
 }
 
-/// Pure parser + sync fetcher for `hermes gateway list --json`. Pre-v0.13
-/// hosts exit non-zero on the unknown subcommand; the fetcher returns `nil`
-/// in that case so the digest row hides itself.
+/// Pure parser + sync fetcher for `hermes gateway list` (Hermes v0.16).
+/// `hermes gateway list` has no `--json` flag — it prints a text table — so
+/// the parser reads that text directly. The fetcher returns `nil` on a
+/// non-zero exit (host without the subcommand) so the digest row hides
+/// itself.
+///
+/// Expected text shape:
+/// ```
+/// Gateways:
+///   ✓ default (current)        — PID 44417
+///   ✗ scarfbox-smoke           — not running
+///   ✗ scarfbox-test            — not running
+/// ```
+/// `✓`/`✗` gives `isRunning`; the word after it is the profile name (a
+/// trailing `(current)` marker is stripped); `— PID <n>` (em dash, U+2014)
+/// carries the pid on running lines. Text output has no per-profile platform
+/// list, so `platforms` is always `[]`.
 ///
 /// The detection is **synchronous** — run from a `Task.detached` to avoid
 /// blocking MainActor on remote SSH round-trips. The pure `parse(_:)`
-/// helper has no I/O and can be used in tests against canned JSON.
+/// helper has no I/O and can be used in tests against canned text.
 public enum HermesGatewayListService {
 
-    /// Parse a JSON blob from `hermes gateway list --json` into a snapshot.
-    /// Tolerant of unknown keys; returns `nil` for unparseable / empty input.
-    ///
-    /// // TODO(WS-5-Q3): the JSON shape below is the plan's best-guess.
-    /// Confirm against actual Hermes v0.13 output once available. Possible
-    /// alternative shapes:
-    /// - root array of profile objects (no `profiles` wrapper)
-    /// - `state` enum string instead of `running` bool
-    /// - `connected_platforms` instead of `platforms`
-    /// The parser is intentionally tolerant so a small shape change can be
-    /// absorbed by tweaking field names without breaking older fixtures.
-    public static func parse(_ json: Data) -> GatewayListSnapshot? {
-        guard !json.isEmpty,
-              let raw = try? JSONSerialization.jsonObject(with: json) else {
-            return nil
-        }
-
-        // Accept both `{"profiles": [...]}` and a bare `[...]` of profiles.
-        let profilesArray: [Any]
-        if let dict = raw as? [String: Any], let arr = dict["profiles"] as? [Any] {
-            profilesArray = arr
-        } else if let arr = raw as? [Any] {
-            profilesArray = arr
-        } else {
-            return nil
-        }
+    /// Parse the text table from `hermes gateway list` into a snapshot.
+    /// Skips the `Gateways:` header; each subsequent profile line yields a
+    /// `ProfileEntry`. `platforms` is always `[]` (the text output omits
+    /// it). Returns `nil` for empty / whitespace-only input.
+    public static func parse(_ text: String) -> GatewayListSnapshot? {
+        let trimmedWhole = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedWhole.isEmpty else { return nil }
 
         var entries: [GatewayListSnapshot.ProfileEntry] = []
-        for raw in profilesArray {
-            guard let obj = raw as? [String: Any] else { continue }
-            let profile = (obj["name"] as? String)
-                ?? (obj["profile"] as? String)
-                ?? "default"
-            let isRunning: Bool
-            if let v = obj["running"] as? Bool {
-                isRunning = v
-            } else if let s = obj["state"] as? String {
-                isRunning = s.lowercased() == "running"
-            } else {
-                isRunning = false
+        for rawLine in text.components(separatedBy: "\n") {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            if line.isEmpty { continue }
+            // Skip the `Gateways:` header (and any other non-profile line
+            // that lacks a running marker).
+            guard line.hasPrefix("✓") || line.hasPrefix("✗") else { continue }
+
+            let isRunning = line.hasPrefix("✓")
+
+            // Strip the marker, then split off the trailing `— …` clause
+            // (em dash, U+2014) which carries pid / status.
+            var rest = String(line.dropFirst()).trimmingCharacters(in: .whitespaces)
+            var pid: Int?
+            if let dashRange = rest.range(of: "—") {
+                let after = rest[dashRange.upperBound...]
+                    .trimmingCharacters(in: .whitespaces)
+                rest = String(rest[..<dashRange.lowerBound])
+                    .trimmingCharacters(in: .whitespaces)
+                // Running lines read `PID <n>`; stopped lines `not running`.
+                if after.hasPrefix("PID") {
+                    let digits = after.drop(while: { !$0.isNumber })
+                    pid = Int(digits.prefix(while: { $0.isNumber }))
+                }
             }
-            let pid = obj["pid"] as? Int
-            let platforms = (obj["platforms"] as? [String])
-                ?? (obj["connected_platforms"] as? [String])
-                ?? []
+
+            // The profile name is the first whitespace-delimited token; a
+            // trailing `(current)` marker is a separate token, so dropping
+            // everything after the first space removes it.
+            let profile = rest
+                .split(whereSeparator: { $0 == " " || $0 == "\t" })
+                .first
+                .map(String.init) ?? ""
+            guard !profile.isEmpty else { continue }
+
             entries.append(GatewayListSnapshot.ProfileEntry(
                 profile: profile,
                 isRunning: isRunning,
                 pid: pid,
-                platforms: platforms
+                platforms: []
             ))
         }
+
+        // No recognizable profile lines (e.g. garbage input) → nil.
+        guard !entries.isEmpty else { return nil }
         return GatewayListSnapshot(profiles: entries)
     }
 
     /// Synchronous fetch helper — call from a `Task.detached`. Returns
-    /// `nil` when the subcommand fails (pre-v0.13 host) or when the
-    /// output isn't parseable.
+    /// `nil` when the subcommand fails (host without `gateway list`) or when
+    /// the output has no recognizable profile lines.
     public static func fetch(context: ServerContext) -> GatewayListSnapshot? {
         let transport = context.makeTransport()
         let executable = context.paths.hermesBinary
         do {
             let result = try transport.runProcess(
                 executable: executable,
-                args: ["gateway", "list", "--json"],
+                args: ["gateway", "list"],
                 stdin: nil,
                 timeout: 10
             )
             guard result.exitCode == 0 else { return nil }
-            return parse(result.stdout)
+            return parse(result.stdoutString)
         } catch {
             return nil
         }

--- a/scarf/Packages/ScarfCore/Sources/ScarfCore/Services/KanbanService.swift
+++ b/scarf/Packages/ScarfCore/Sources/ScarfCore/Services/KanbanService.swift
@@ -432,31 +432,11 @@ public actor KanbanService {
 
     // MARK: - Hallucination gate (v0.13)
 
-    /// Mark a worker-created card as user-verified — flips
-    /// `hallucination_gate_status` from `pending` to `verified` so the
-    /// dispatcher can pick it up. The polling loop picks up the new
-    /// state on the next tick (and the VM optimistically clears the
-    /// pending banner immediately on the click).
-    ///
-    /// **Pre-v0.13 hosts:** the verb doesn't exist; callers MUST gate
-    /// on `HermesCapabilities.hasKanbanDiagnostics` before invoking this.
-    /// A pre-v0.13 binary will surface the failure as
-    /// `KanbanError.nonZeroExit` with stderr containing "unknown command".
-    // TODO(WS-3-Q1): Confirm the exact CLI verb name for the
-    // hallucination-gate verify path against a v0.13 binary (`hermes
-    // kanban --help`). The v0.13 release notes describe "hallucination
-    // gate + recovery UX" but don't enumerate the verb name. This
-    // implementation assumes `hermes kanban verify <id>`. If Hermes ships
-    // it as `hermes kanban gate verify <id>`, `hermes kanban hallucination
-    // verify <id>`, or another name, update the args here. The Reject
-    // path does NOT depend on this verb (it routes through
-    // `archive` + a comment), so the recovery UX stays functional even
-    // if Verify is a stub for an early v0.13.x.
-    public func verify(taskId: String) async throws {
-        let args = prefix("verify", taskId)
-        let (code, _, stderr) = await runHermes(args: args, timeout: 15)
-        try ensureSuccess(code: code, stdout: "", stderr: stderr, verb: "verify")
-    }
+    // NOTE: there is NO `hermes kanban verify` verb in Hermes (re-verified
+    // against v0.16 — `kanban` has no verify/reject subcommand). The
+    // former `verify(taskId:)` shelled a non-existent verb and has been
+    // removed. Rejection (below) routes through the real `comment` +
+    // `archive` verbs, so the recovery UX stays functional.
 
     /// Reject a worker-created card as a hallucinated reference. There
     /// is no dedicated `kanban reject` verb in v0.13; the right action

--- a/scarf/Packages/ScarfCore/Sources/ScarfCore/ViewModels/RichChatViewModel.swift
+++ b/scarf/Packages/ScarfCore/Sources/ScarfCore/ViewModels/RichChatViewModel.swift
@@ -390,6 +390,13 @@ public final class RichChatViewModel {
     // list and route it through the standard send path (the pill
     // bookkeeping in `recordActiveGoal` is independent of the
     // interruptive classification).
+    // NOTE: `/goal` and `/subgoal` are NOT advertised here. They are
+    // gateway-only verbs — the ACP adapter does not advertise them in its
+    // command set (re-verified against Hermes v0.16), so surfacing them in
+    // the ACP slash menu showed rows that no-op against an ACP host. The
+    // optimistic goal/subgoal pill plumbing (`recordActiveGoal`,
+    // `activeSubgoals`, the `SessionInfoBar` pill) is left intact for the
+    // typed-command path and for any future gateway-fronted surface.
     public static let nonInterruptiveCommands: [HermesSlashCommand] = [
         HermesSlashCommand(
             name: "steer",
@@ -398,25 +405,9 @@ public final class RichChatViewModel {
             source: .acpNonInterruptive
         ),
         HermesSlashCommand(
-            name: "goal",
-            description: "Lock the agent on a goal that persists across turns",
-            argumentHint: "<text>",
-            source: .acpNonInterruptive
-        ),
-        HermesSlashCommand(
             name: "queue",
             description: "Queue a prompt to run after the current turn",
             argumentHint: "<text>",
-            source: .acpNonInterruptive
-        ),
-        // v0.14 — extra criteria layered onto the active /goal loop.
-        // Hermes parses `/subgoal <text>`, `/subgoal remove N`, and
-        // `/subgoal clear` server-side; Scarf mirrors the active list
-        // in `activeSubgoals` for the pill render.
-        HermesSlashCommand(
-            name: "subgoal",
-            description: "Add or manage extra criteria on the active goal",
-            argumentHint: "<text | remove N | clear>",
             source: .acpNonInterruptive
         )
     ]
@@ -651,16 +642,16 @@ public final class RichChatViewModel {
             .union(projectNames)
             .union(globalNames)
             .union(Set(quicks.map(\.name)))
-        // Capability gate: `/goal` and `/queue` are v0.13+ surfaces;
-        // hide them when the connected host is older. `/steer` is
-        // surfaced unconditionally — it works on v0.11+ during an
-        // active turn; idle-session greying for pre-v0.13 hosts is
-        // the input bar's concern (it reads `hasACPSteerOnIdle`).
+        // Capability gate: `/queue` is a v0.13+ surface; hide it when the
+        // connected host is older. `/steer` is surfaced unconditionally —
+        // it works on v0.11+ during an active turn; idle-session greying
+        // for pre-v0.13 hosts is the input bar's concern (it reads
+        // `hasACPSteerOnIdle`). `/goal` and `/subgoal` are deliberately
+        // NOT in `nonInterruptiveCommands` (gateway-only, not advertised
+        // by the ACP adapter), so they never reach this filter.
         let supported: [HermesSlashCommand] = Self.nonInterruptiveCommands.filter { cmd in
             switch cmd.name {
-            case "goal":    return capabilitiesGate.hasGoals
             case "queue":   return capabilitiesGate.hasACPQueue
-            case "subgoal": return capabilitiesGate.hasSubgoal
             // P2 of the projects-feature fix: /steer used to be filtered
             // out pre-session, which made the menu look empty on fresh
             // app launches. Now it stays visible and `disabledSlash-
@@ -988,7 +979,7 @@ public final class RichChatViewModel {
         "clear", "compact", "cost", "model", "tools",
         "reload-skills", "help", "exit",
         "yolo", "sessions", "codex-runtime",
-        "steer", "goal", "queue", "subgoal"
+        "steer", "queue"
     ]
 
     /// Tooltip / inline help text shown next to disabled rows. Returns

--- a/scarf/Packages/ScarfCore/Tests/ScarfCoreTests/GatewayAllowlistKindTests.swift
+++ b/scarf/Packages/ScarfCore/Tests/ScarfCoreTests/GatewayAllowlistKindTests.swift
@@ -13,7 +13,8 @@ import Foundation
         #expect(GatewayAllowlistKind.kind(for: "telegram")   == .chats)
         #expect(GatewayAllowlistKind.kind(for: "whatsapp")   == .chats)
         #expect(GatewayAllowlistKind.kind(for: "matrix")     == .rooms)
-        #expect(GatewayAllowlistKind.kind(for: "dingtalk")   == .rooms)
+        // v0.16: Hermes reads `dingtalk.allowed_chats`, not allowed_rooms.
+        #expect(GatewayAllowlistKind.kind(for: "dingtalk")   == .chats)
     }
 
     @Test func acceptsBothGoogleChatSpellings() {

--- a/scarf/Packages/ScarfCore/Tests/ScarfCoreTests/GatewayConfigWriterTests.swift
+++ b/scarf/Packages/ScarfCore/Tests/ScarfCoreTests/GatewayConfigWriterTests.swift
@@ -4,6 +4,10 @@ import Foundation
 
 /// Round-trip + idempotence tests for `GatewayConfigWriter.setList`. Pure
 /// `String` operations only — runs cleanly on Linux SwiftPM.
+///
+/// Hermes v0.16 reads allowlists from top-level `<platform>.allowed_*`
+/// sections, so every assertion below targets that path (NOT the old
+/// `gateway.platforms.<platform>.*` lineage).
 @Suite struct GatewayConfigWriterTests {
 
     // MARK: - Insert
@@ -16,12 +20,13 @@ import Foundation
             key: "allowed_channels",
             items: ["C0123ABCD", "C0456EFGH"]
         )
-        #expect(updated.contains("gateway:"))
-        #expect(updated.contains("  platforms:"))
-        #expect(updated.contains("    slack:"))
-        #expect(updated.contains("      allowed_channels:"))
-        #expect(updated.contains("- C0123ABCD"))
-        #expect(updated.contains("- C0456EFGH"))
+        // Top-level `slack:` section, NOT `gateway.platforms.slack`.
+        #expect(updated.contains("slack:"))
+        #expect(!updated.contains("gateway:"))
+        #expect(!updated.contains("platforms:"))
+        #expect(updated.contains("  allowed_channels:"))
+        #expect(updated.contains("    - C0123ABCD"))
+        #expect(updated.contains("    - C0456EFGH"))
     }
 
     @Test func setListAppendsScaffoldPreservingPriorContent() {
@@ -40,22 +45,20 @@ import Foundation
         #expect(updated.contains("model:"))
         #expect(updated.contains("  default: gpt-4o"))
         #expect(updated.contains("  provider: openai"))
-        // New scaffold appended.
-        #expect(updated.contains("gateway:"))
-        #expect(updated.contains("    slack:"))
-        #expect(updated.contains("- C01"))
+        // New top-level `slack:` scaffold appended.
+        #expect(updated.contains("slack:"))
+        #expect(updated.contains("  allowed_channels:"))
+        #expect(updated.contains("    - C01"))
     }
 
     // MARK: - Replace
 
     @Test func setListReplacesExistingBlock() {
         let yaml = """
-        gateway:
-          platforms:
-            slack:
-              allowed_channels:
-                - C_OLD_1
-                - C_OLD_2
+        slack:
+          allowed_channels:
+            - C_OLD_1
+            - C_OLD_2
         """
         let updated = GatewayConfigWriter.setList(
             in: yaml,
@@ -69,16 +72,16 @@ import Foundation
     }
 
     @Test func setListPreservesScalarSiblings() {
-        // The `busy_ack_enabled` scalar sibling of `allowed_channels` must
-        // stay byte-for-byte after a list-write to the same platform.
+        // The `gateway_restart_notification` scalar sibling of
+        // `allowed_channels` (plus any Scarf-managed key like
+        // `reply_to_mode`) must stay byte-for-byte after a list-write to the
+        // same platform.
         let yaml = """
-        gateway:
-          platforms:
-            slack:
-              allowed_channels:
-                - C_OLD
-              busy_ack_enabled: false
-              gateway_restart_notification: true
+        slack:
+          allowed_channels:
+            - C_OLD
+          reply_to_mode: thread
+          gateway_restart_notification: true
         """
         let updated = GatewayConfigWriter.setList(
             in: yaml,
@@ -89,22 +92,47 @@ import Foundation
         #expect(updated.contains("- C_NEW"))
         #expect(!updated.contains("- C_OLD"))
         // Scalars at the same indent must survive.
-        #expect(updated.contains("busy_ack_enabled: false"))
+        #expect(updated.contains("reply_to_mode: thread"))
         #expect(updated.contains("gateway_restart_notification: true"))
+    }
+
+    @Test func setListMergesIntoExistingPlatformSectionPreservingSiblingKey() {
+        // CRITICAL merge case: `slack:` already holds a Scarf-managed
+        // sibling (`reply_to_mode`) but no `allowed_channels` yet. Writing
+        // the allowlist must splice the key into the EXISTING section, not
+        // clobber it or append a duplicate `slack:` block.
+        let yaml = """
+        slack:
+          reply_to_mode: thread
+        """
+        let updated = GatewayConfigWriter.setList(
+            in: yaml,
+            platform: "slack",
+            key: "allowed_channels",
+            items: ["C99"]
+        )
+        // Sibling key preserved.
+        #expect(updated.contains("reply_to_mode: thread"))
+        // Allowlist landed under the same section.
+        #expect(updated.contains("  allowed_channels:"))
+        #expect(updated.contains("    - C99"))
+        // Exactly one `slack:` header — no duplicate section appended.
+        let slackHeaders = updated
+            .components(separatedBy: "\n")
+            .filter { $0 == "slack:" }
+        #expect(slackHeaders.count == 1)
     }
 
     @Test func setListPreservesOtherPlatformsBlocks() {
         // Editing slack must not touch matrix.
         let yaml = """
-        gateway:
-          platforms:
-            slack:
-              allowed_channels:
-                - C_SLACK
-            matrix:
-              allowed_rooms:
-                - '!room1:matrix.org'
-                - '!room2:matrix.org'
+        slack:
+          allowed_channels:
+            - C_SLACK
+        matrix:
+          allowed_rooms:
+            - '!room1:matrix.org'
+            - '!room2:matrix.org'
         """
         let updated = GatewayConfigWriter.setList(
             in: yaml,
@@ -114,7 +142,7 @@ import Foundation
         )
         #expect(updated.contains("- C_SLACK_NEW"))
         // Matrix block intact.
-        #expect(updated.contains("    matrix:"))
+        #expect(updated.contains("matrix:"))
         #expect(updated.contains("'!room1:matrix.org'"))
         #expect(updated.contains("'!room2:matrix.org'"))
     }
@@ -123,13 +151,11 @@ import Foundation
 
     @Test func setListWithEmptyItemsRemovesBlock() {
         let yaml = """
-        gateway:
-          platforms:
-            slack:
-              allowed_channels:
-                - C01
-                - C02
-              busy_ack_enabled: true
+        slack:
+          allowed_channels:
+            - C01
+            - C02
+          gateway_restart_notification: true
         """
         let updated = GatewayConfigWriter.setList(
             in: yaml,
@@ -141,7 +167,7 @@ import Foundation
         #expect(!updated.contains("allowed_channels:"))
         #expect(!updated.contains("- C01"))
         #expect(!updated.contains("- C02"))
-        #expect(updated.contains("busy_ack_enabled: true"))
+        #expect(updated.contains("gateway_restart_notification: true"))
     }
 
     @Test func setListWithEmptyItemsOnAbsentBlockIsNoOp() {
@@ -238,23 +264,21 @@ import Foundation
         #expect(updated.contains("'weird:''name'"))
     }
 
-    // MARK: - Insertion when ancestors exist but key is absent
+    // MARK: - Insertion when section exists but key is absent
 
     @Test func setListInsertsKeyUnderExistingPlatformBlock() {
-        // `gateway → platforms → slack` exists with a busy_ack_enabled
+        // Top-level `slack:` exists with a `gateway_restart_notification`
         // scalar; `allowed_channels` is missing. Add it without disturbing
         // the scalar sibling.
         let yaml = """
-        gateway:
-          platforms:
-            slack:
-              busy_ack_enabled: false
+        slack:
+          gateway_restart_notification: false
         """
         let updated = GatewayConfigWriter.setList(
             in: yaml, platform: "slack", key: "allowed_channels",
             items: ["C42"]
         )
-        #expect(updated.contains("busy_ack_enabled: false"))
+        #expect(updated.contains("gateway_restart_notification: false"))
         #expect(updated.contains("allowed_channels:"))
         #expect(updated.contains("- C42"))
     }
@@ -263,7 +287,9 @@ import Foundation
 
     @Test func roundTripsThroughHermesConfigYAMLLoader() {
         // Write a list, then parse the result through HermesConfig+YAML and
-        // confirm we read back what we wrote.
+        // confirm we read back what we wrote — proving the writer lands the
+        // allowlist exactly where the reader looks (top-level
+        // `slack.allowed_channels`).
         var yaml = ""
         yaml = GatewayConfigWriter.setList(
             in: yaml, platform: "slack", key: "allowed_channels",
@@ -272,5 +298,25 @@ import Foundation
         let cfg = HermesConfig(yaml: yaml)
         let block = cfg.gatewayPlatforms["slack"]
         #expect(block?.allowedChannels == ["C01", "C02"])
+    }
+
+    @Test func roundTripMergesAndPreservesSiblingThroughLoader() {
+        // Full merge round-trip: an existing `slack:` section with a sibling
+        // key, write an allowlist, confirm via the loader that the allowlist
+        // lands at `slack.allowed_channels` (NOT
+        // `gateway.platforms.slack.allowed_channels`) and the sibling
+        // survives.
+        let yaml = """
+        slack:
+          reply_to_mode: thread
+        """
+        let updated = GatewayConfigWriter.setList(
+            in: yaml, platform: "slack", key: "allowed_channels",
+            items: ["C7", "C8"]
+        )
+        let cfg = HermesConfig(yaml: updated)
+        #expect(cfg.gatewayPlatforms["slack"]?.allowedChannels == ["C7", "C8"])
+        // Sibling key still present in the raw YAML.
+        #expect(updated.contains("reply_to_mode: thread"))
     }
 }

--- a/scarf/Packages/ScarfCore/Tests/ScarfCoreTests/HermesGatewayListServiceTests.swift
+++ b/scarf/Packages/ScarfCore/Tests/ScarfCoreTests/HermesGatewayListServiceTests.swift
@@ -2,89 +2,86 @@ import Testing
 import Foundation
 @testable import ScarfCore
 
-/// Parser tests for `hermes gateway list --json`. Pure — no transport, no
-/// process calls.
+/// Parser tests for the `hermes gateway list` text table (Hermes v0.16 has
+/// no `--json` flag). Pure — no transport, no process calls.
 @Suite struct HermesGatewayListServiceTests {
 
-    private func data(_ s: String) -> Data { s.data(using: .utf8)! }
+    @Test func parsesLiveSampleOneRunningTwoStopped() {
+        // The exact live v0.16 output: 1 running default + 2 stopped.
+        let text = """
+        Gateways:
+          ✓ default (current)        — PID 44417
+          ✗ scarfbox-smoke           — not running
+          ✗ scarfbox-test            — not running
+        """
+        let snap = HermesGatewayListService.parse(text)
+        #expect(snap?.profiles.count == 3)
 
-    @Test func parsesSingleProfileSinglePlatform() {
-        let json = data(#"""
-        {"profiles":[{"name":"default","running":true,"pid":1234,
-        "platforms":["slack","telegram"]}]}
-        """#)
-        let snap = HermesGatewayListService.parse(json)
+        #expect(snap?.profiles[0].profile == "default")
+        #expect(snap?.profiles[0].isRunning == true)
+        #expect(snap?.profiles[0].pid == 44417)
+        #expect(snap?.profiles[0].platforms.isEmpty == true)
+
+        #expect(snap?.profiles[1].profile == "scarfbox-smoke")
+        #expect(snap?.profiles[1].isRunning == false)
+        #expect(snap?.profiles[1].pid == nil)
+
+        #expect(snap?.profiles[2].profile == "scarfbox-test")
+        #expect(snap?.profiles[2].isRunning == false)
+        #expect(snap?.profiles[2].pid == nil)
+    }
+
+    @Test func parsesSingleRunningProfile() {
+        let text = """
+        Gateways:
+          ✓ default        — PID 1234
+        """
+        let snap = HermesGatewayListService.parse(text)
         #expect(snap?.profiles.count == 1)
         #expect(snap?.profiles[0].profile == "default")
         #expect(snap?.profiles[0].pid == 1234)
         #expect(snap?.profiles[0].isRunning == true)
-        #expect(snap?.profiles[0].platforms == ["slack", "telegram"])
+        #expect(snap?.profiles[0].platforms.isEmpty == true)
     }
 
-    @Test func parsesMultipleProfiles() {
-        let json = data(#"""
-        {"profiles":[
-            {"name":"work","running":true,"pid":2001,"platforms":["slack"]},
-            {"name":"personal","running":false,"platforms":["telegram"]}
-        ]}
-        """#)
-        let snap = HermesGatewayListService.parse(json)
-        #expect(snap?.profiles.count == 2)
-        #expect(snap?.profiles[0].profile == "work")
-        #expect(snap?.profiles[0].isRunning == true)
-        #expect(snap?.profiles[1].profile == "personal")
-        #expect(snap?.profiles[1].isRunning == false)
-        #expect(snap?.profiles[1].pid == nil)
-    }
-
-    @Test func parsesBareArrayShape() {
-        // Tolerance for a top-level array (no `profiles` wrapper).
-        let json = data(#"""
-        [{"name":"default","running":true,"pid":42,"platforms":["discord"]}]
-        """#)
-        let snap = HermesGatewayListService.parse(json)
+    @Test func parsesSingleStoppedProfile() {
+        let text = """
+        Gateways:
+          ✗ default        — not running
+        """
+        let snap = HermesGatewayListService.parse(text)
         #expect(snap?.profiles.count == 1)
         #expect(snap?.profiles[0].profile == "default")
+        #expect(snap?.profiles[0].isRunning == false)
+        #expect(snap?.profiles[0].pid == nil)
     }
 
-    @Test func toleratesAlternateFieldNames() {
-        // `profile` instead of `name`, `state` instead of `running`,
-        // `connected_platforms` instead of `platforms` — defensive defaults
-        // keep the parser happy if Hermes ships any of these.
-        let json = data(#"""
-        {"profiles":[{"profile":"alt","state":"running","pid":7,
-        "connected_platforms":["matrix"]}]}
-        """#)
-        let snap = HermesGatewayListService.parse(json)
-        #expect(snap?.profiles[0].profile == "alt")
-        #expect(snap?.profiles[0].isRunning == true)
-        #expect(snap?.profiles[0].platforms == ["matrix"])
+    @Test func stripsCurrentMarkerFromProfileName() {
+        // A `(current)` marker after the profile name must not leak into it.
+        let text = """
+        Gateways:
+          ✓ work (current)        — PID 99
+        """
+        let snap = HermesGatewayListService.parse(text)
+        #expect(snap?.profiles[0].profile == "work")
+        #expect(snap?.profiles[0].pid == 99)
     }
 
-    @Test func returnsNilOnEmptyData() {
-        #expect(HermesGatewayListService.parse(Data()) == nil)
+    @Test func returnsNilOnEmptyString() {
+        #expect(HermesGatewayListService.parse("") == nil)
     }
 
-    @Test func returnsNilOnUnparseableJSON() {
-        let json = data("not-json")
-        #expect(HermesGatewayListService.parse(json) == nil)
+    @Test func returnsNilOnWhitespaceOnly() {
+        #expect(HermesGatewayListService.parse("   \n  \n") == nil)
     }
 
-    @Test func returnsEmptySnapshotOnEmptyProfilesArray() {
-        let json = data(#"{"profiles":[]}"#)
-        let snap = HermesGatewayListService.parse(json)
-        #expect(snap?.profiles.isEmpty == true)
+    @Test func returnsNilOnHeaderOnlyNoProfiles() {
+        // Just the header, no profile rows → no recognizable entries → nil.
+        #expect(HermesGatewayListService.parse("Gateways:\n") == nil)
     }
 
-    @Test func toleratesUnknownKeys() {
-        // Forward-compat: a future v0.13.x Hermes adds extra fields, parser
-        // still works.
-        let json = data(#"""
-        {"profiles":[{"name":"default","running":true,"platforms":["slack"],
-        "future_field":"value","another":42}]}
-        """#)
-        let snap = HermesGatewayListService.parse(json)
-        #expect(snap?.profiles[0].profile == "default")
+    @Test func returnsNilOnGarbageInput() {
+        #expect(HermesGatewayListService.parse("this is not gateway output") == nil)
     }
 
     // MARK: - headerDigest

--- a/scarf/Packages/ScarfCore/Tests/ScarfCoreTests/M6ConfigCronTests.swift
+++ b/scarf/Packages/ScarfCore/Tests/ScarfCoreTests/M6ConfigCronTests.swift
@@ -286,7 +286,7 @@ import Foundation
         #expect(c.timezone == "America/New_York")
     }
 
-    // MARK: - v0.13 gateway.platforms.<platform> block
+    // MARK: - v0.16 top-level <platform>.allowed_* allowlists
 
     @Test func gatewayPlatformsEmptyByDefault() {
         let c = HermesConfig(yaml: "")
@@ -294,16 +294,15 @@ import Foundation
     }
 
     @Test func parsesGatewayAllowlistsForSlack() {
+        // v0.16: allowlists live at top-level `slack.allowed_*`.
         let yaml = """
-        gateway:
-          platforms:
-            slack:
-              allowed_channels:
-                - C01
-                - C02
-              busy_ack_enabled: false
-              gateway_restart_notification: true
-              slash_command_notice_ttl_seconds: 120
+        slack:
+          allowed_channels:
+            - C01
+            - C02
+          busy_ack_enabled: false
+          gateway_restart_notification: true
+          slash_command_notice_ttl_seconds: 120
         """
         let cfg = HermesConfig(yaml: yaml)
         let block = cfg.gatewayPlatforms["slack"]
@@ -315,51 +314,57 @@ import Foundation
 
     @Test func parsesGatewayAllowlistsForTelegramAndMatrix() {
         let yaml = """
-        gateway:
-          platforms:
-            telegram:
-              allowed_chats:
-                - '@alice'
-                - '12345'
-            matrix:
-              allowed_rooms:
-                - '!room:matrix.org'
+        telegram:
+          allowed_chats:
+            - '@alice'
+            - '12345'
+        matrix:
+          allowed_rooms:
+            - '!room:matrix.org'
         """
         let cfg = HermesConfig(yaml: yaml)
         #expect(cfg.gatewayPlatforms["telegram"]?.allowedChats == ["@alice", "12345"])
         #expect(cfg.gatewayPlatforms["matrix"]?.allowedRooms == ["!room:matrix.org"])
     }
 
-    @Test func gatewayBlockCoexistsWithLegacyPlatformBlocks() {
-        // Regression: legacy `platforms.slack.reply_to_mode` and
-        // `matrix.require_mention` must keep parsing when the new
-        // `gateway:` block is also present — no key collisions.
+    @Test func parsesGatewayAllowlistForDingtalkAsChats() {
+        // v0.16: Hermes reads `dingtalk.allowed_chats` (NOT allowed_rooms).
         let yaml = """
-        platforms:
-          slack:
-            reply_to_mode: all
+        dingtalk:
+          allowed_chats:
+            - cidABC123
+        """
+        let cfg = HermesConfig(yaml: yaml)
+        #expect(cfg.gatewayPlatforms["dingtalk"]?.allowedChats == ["cidABC123"])
+    }
+
+    @Test func gatewayAllowlistCoexistsWithLegacyPlatformKeys() {
+        // Regression: the legacy `slack.reply_to_mode` /
+        // `matrix.require_mention` keys live in the SAME top-level section as
+        // the v0.16 allowlist keys — both must keep parsing, no collisions.
+        let yaml = """
+        slack:
+          reply_to_mode: all
+          allowed_channels:
+            - C01
         matrix:
           require_mention: false
-        gateway:
-          platforms:
-            slack:
-              allowed_channels:
-                - C01
+          allowed_rooms:
+            - '!room:matrix.org'
         """
         let cfg = HermesConfig(yaml: yaml)
         #expect(cfg.slack.replyToMode == "all")
         #expect(cfg.matrix.requireMention == false)
         #expect(cfg.gatewayPlatforms["slack"]?.allowedChannels == ["C01"])
+        #expect(cfg.gatewayPlatforms["matrix"]?.allowedRooms == ["!room:matrix.org"])
     }
 
-    @Test func gatewayPlatformsSkipsPlatformsWithoutV013Keys() {
-        // The `gateway:` block exists but only Slack has a v0.13 key —
-        // platforms without keys must NOT appear in `gatewayPlatforms`.
+    @Test func gatewayPlatformsSkipsPlatformsWithoutGatewayKeys() {
+        // Only Slack carries a gateway key — platforms without one must NOT
+        // appear in `gatewayPlatforms`.
         let yaml = """
-        gateway:
-          platforms:
-            slack:
-              busy_ack_enabled: true
+        slack:
+          busy_ack_enabled: true
         """
         let cfg = HermesConfig(yaml: yaml)
         #expect(cfg.gatewayPlatforms["slack"] != nil)

--- a/scarf/Packages/ScarfCore/Tests/ScarfCoreTests/M6ConfigCronTests.swift
+++ b/scarf/Packages/ScarfCore/Tests/ScarfCoreTests/M6ConfigCronTests.swift
@@ -99,20 +99,41 @@ import Foundation
     }
 
     @Test func parsesImageGenAndOpenRouterCache() {
-        // WS-6: round-trip the two new top-level v0.13 keys. If the
-        // OpenRouter key shape changes upstream (see TODO(WS-6-Q1)),
-        // this test is the single touchpoint that pins the parser
-        // line + setter key + UI binding to a single shape.
+        // WS-6 / v0.16: round-trip the two new top-level keys. Hermes
+        // v0.16 reads `openrouter.response_cache` as a SCALAR bool
+        // directly under `openrouter:`. This test pins the parser line +
+        // setter key + UI binding to that single shape.
         let yaml = """
         image_gen:
           model: openai/gpt-image-1
         openrouter:
-          response_cache:
-            enabled: true
+          response_cache: true
         """
         let c = HermesConfig(yaml: yaml)
         #expect(c.imageGenModel == "openai/gpt-image-1")
         #expect(c.openrouterResponseCacheEnabled == true)
+    }
+
+    @Test func openRouterResponseCacheScalarFalseDecodes() {
+        // The scalar `false` round-trips honestly (the v0.16 bug was that
+        // a disable wrote a nested dict that Hermes read as truthy).
+        let c = HermesConfig(yaml: """
+        openrouter:
+          response_cache: false
+        """)
+        #expect(c.openrouterResponseCacheEnabled == false)
+    }
+
+    @Test func openRouterResponseCacheLegacyNestedDecodesToFalse() {
+        // Defensive read: a legacy nested value flattens to a different
+        // dotted key, so the scalar lookup misses and we fall to the
+        // `false` default. The next save writes the scalar, healing it.
+        let c = HermesConfig(yaml: """
+        openrouter:
+          response_cache:
+            enabled: true
+        """)
+        #expect(c.openrouterResponseCacheEnabled == false)
     }
 
     @Test func parsesBitwardenSecretsBlock() {

--- a/scarf/Packages/ScarfCore/Tests/ScarfCoreTests/M9SlashCommandTests.swift
+++ b/scarf/Packages/ScarfCore/Tests/ScarfCoreTests/M9SlashCommandTests.swift
@@ -243,19 +243,28 @@ import Foundation
 
     // MARK: - v0.13 non-interruptive commands (WS-2 / Persistent Goals + /queue)
 
-    @Test func nonInterruptiveListIncludesGoalAndQueue() {
+    @Test func nonInterruptiveListIncludesSteerAndQueueNotGoal() {
+        // `/goal` and `/subgoal` are gateway-only and NOT advertised by
+        // the ACP adapter, so they are no longer in this set (they used
+        // to surface ACP slash-menu rows that no-op'd).
         let names = RichChatViewModel.nonInterruptiveCommands.map(\.name)
         #expect(names.contains("steer"))
-        #expect(names.contains("goal"))
         #expect(names.contains("queue"))
+        #expect(!names.contains("goal"))
+        #expect(!names.contains("subgoal"))
     }
 
     @MainActor
-    @Test func availableCommandsHidesGoalWhenCapabilityOff() {
+    @Test func availableCommandsNeverSurfacesGoalOrSubgoal() {
+        // Even on a v0.13+ host with an active session, `/goal` and
+        // `/subgoal` are not surfaced in the ACP slash menu.
         let vm = RichChatViewModel(context: .local)
-        vm.publishCapabilities(.empty)
+        vm.setSessionId("scratch-session")
+        let caps = HermesCapabilities.parseLine("Hermes Agent v0.14.0 (2026.5.7)")
+        vm.publishCapabilities(caps)
         let names = vm.availableCommands.map(\.name)
         #expect(!names.contains("goal"))
+        #expect(!names.contains("subgoal"))
     }
 
     @MainActor
@@ -267,7 +276,7 @@ import Foundation
     }
 
     @MainActor
-    @Test func availableCommandsExposesAllThreeOnV013() {
+    @Test func availableCommandsExposesSteerAndQueueOnV013() {
         let vm = RichChatViewModel(context: .local)
         // /steer is gated on having an active session — nudging an
         // agent that isn't running has nothing to act on. Engage so
@@ -277,7 +286,6 @@ import Foundation
         vm.publishCapabilities(caps)
         let names = vm.availableCommands.map(\.name)
         #expect(names.contains("steer"))
-        #expect(names.contains("goal"))
         #expect(names.contains("queue"))
     }
 
@@ -289,7 +297,6 @@ import Foundation
         vm.publishCapabilities(caps)
         let names = vm.availableCommands.map(\.name)
         #expect(names.contains("steer"))
-        #expect(!names.contains("goal"))
         #expect(!names.contains("queue"))
     }
 
@@ -421,16 +428,17 @@ import Foundation
     }
 
     @MainActor
-    @Test func subgoalMenuRespectsCapabilityGate() {
+    @Test func subgoalNeverSurfacedInACPMenu() {
+        // `/subgoal` is a gateway-only verb (not advertised by the ACP
+        // adapter), so it never appears in the ACP slash menu — on any
+        // host version.
         let vm = RichChatViewModel(context: .local)
-        // No /subgoal on a v0.13 host.
         vm.publishCapabilities(HermesCapabilities.parseLine("Hermes Agent v0.13.0 (2026.5.7)"))
         var names = vm.availableCommands.map(\.name)
         #expect(!names.contains("subgoal"))
-        // /subgoal shows up on a v0.14 host.
         vm.publishCapabilities(HermesCapabilities.parseLine("Hermes Agent v0.14.0 (2026.5.16)"))
         names = vm.availableCommands.map(\.name)
-        #expect(names.contains("subgoal"))
+        #expect(!names.contains("subgoal"))
     }
 
     @MainActor
@@ -465,16 +473,18 @@ import Foundation
         #expect(vm.popQueuedPrompt() == nil)
     }
 
-    @Test func isNonInterruptiveSlashRecognizesGoalAndQueue() {
+    @Test func isNonInterruptiveSlashRecognizesSteerAndQueueNotGoal() {
         // Non-MainActor: the helper itself isn't MainActor-isolated;
         // construct a VM on MainActor and read through it on the test
         // actor to keep the assertion focused on classification.
+        // `/goal` is no longer an ACP non-interruptive command (gateway-
+        // only); its typed-command path has its own explicit dispatch arm.
         Task { @MainActor in
             let vm = RichChatViewModel(context: .local)
-            #expect(vm.isNonInterruptiveSlash("/goal finish v2.8"))
             #expect(vm.isNonInterruptiveSlash("/queue summarize"))
             #expect(vm.isNonInterruptiveSlash("/queue"))
             #expect(vm.isNonInterruptiveSlash("/steer be careful"))
+            #expect(!vm.isNonInterruptiveSlash("/goal finish v2.8"))
             #expect(!vm.isNonInterruptiveSlash("hello"))
             #expect(!vm.isNonInterruptiveSlash("/compress"))
         }

--- a/scarf/Packages/ScarfCore/Tests/ScarfCoreTests/SlashMenuLogicTests.swift
+++ b/scarf/Packages/ScarfCore/Tests/ScarfCoreTests/SlashMenuLogicTests.swift
@@ -218,7 +218,10 @@ import Foundation
         #expect(disabled.contains("model"))
         #expect(disabled.contains("yolo"))
         #expect(disabled.contains("steer"))
-        #expect(disabled.contains("goal"))
+        #expect(disabled.contains("queue"))
+        // `/goal` is gateway-only (not advertised by the ACP adapter), so
+        // it is not in the session-required set and never greyed.
+        #expect(!disabled.contains("goal"))
         // `/new` is NEVER session-required — it's how you GET a session.
         #expect(!disabled.contains("new"))
     }
@@ -237,7 +240,7 @@ import Foundation
     // MARK: - availableCommands capability gating
 
     @MainActor
-    @Test func availableCommandsHidesGoalAndQueueOnPreV013() {
+    @Test func availableCommandsHidesQueueOnPreV013() {
         let vm = RichChatViewModel(context: .local)
         // /steer requires an active session to be in the menu —
         // nudging an idle (no-session) VM is a no-op. Engage so the
@@ -252,14 +255,16 @@ import Foundation
             )
         )
         let names = Set(vm.availableCommands.map(\.name))
-        #expect(!names.contains("goal"))
         #expect(!names.contains("queue"))
         #expect(names.contains("steer"))
         #expect(names.contains("new"))
+        // `/goal` and `/subgoal` are gateway-only — never surfaced.
+        #expect(!names.contains("goal"))
+        #expect(!names.contains("subgoal"))
     }
 
     @MainActor
-    @Test func availableCommandsExposesGoalAndQueueOnV013() {
+    @Test func availableCommandsExposesQueueOnV013ButNeverGoal() {
         let vm = RichChatViewModel(context: .local)
         vm.setSessionId("scratch-session")
         vm.publishCapabilities(
@@ -270,10 +275,12 @@ import Foundation
             )
         )
         let names = Set(vm.availableCommands.map(\.name))
-        #expect(names.contains("goal"))
         #expect(names.contains("queue"))
         #expect(names.contains("steer"))
         #expect(names.contains("new"))
+        // `/goal` and `/subgoal` are NOT advertised by the ACP adapter.
+        #expect(!names.contains("goal"))
+        #expect(!names.contains("subgoal"))
     }
 
     // MARK: - clientSideSlashCommand

--- a/scarf/scarf/Core/Services/HermesFileService.swift
+++ b/scarf/scarf/Core/Services/HermesFileService.swift
@@ -717,20 +717,33 @@ struct HermesFileService: Sendable {
     }
 
     /// Adds an SSE-transport MCP server. v0.13+ only — caller is responsible
-    /// for capability-gating; pre-v0.13 hosts will reject the `--transport`
-    /// flag at argparse time. The optional `sseReadTimeout` is passed via
-    /// `--sse-read-timeout <int>` and persisted as `sse_read_timeout: <int>`
-    /// in the YAML entry.
-    // TODO(WS-7-Q3): Verify exact CLI flag spelling against `hermes mcp add --help`
-    // on a v0.13 install. Plan assumes `--transport sse` + `--sse-read-timeout`;
-    // alternatives could be `--sse` (boolean) + `--read-timeout`.
+    /// for capability-gating.
+    ///
+    /// Hermes v0.16 `mcp add` only understands `--url` (there is NO
+    /// `--transport` / `--sse-read-timeout` flag — they'd be rejected at
+    /// argparse time). So we create the entry with `hermes mcp add --url`
+    /// (which produces a remote/HTTP-shaped block) and then write the
+    /// `transport: sse` (+ optional `sse_read_timeout`) scalars into that
+    /// server's YAML block via the same surgical patcher the rest of the
+    /// MCP YAML surface uses. The `transport: sse` scalar is what the
+    /// reader keys on to discriminate SSE from HTTP.
     @discardableResult
     nonisolated func addMCPServerSSE(name: String, url: String, sseReadTimeout: Int?) -> (exitCode: Int32, output: String) {
-        var cliArgs: [String] = ["mcp", "add", name, "--url", url, "--transport", "sse"]
-        if let timeout = sseReadTimeout {
-            cliArgs.append(contentsOf: ["--sse-read-timeout", String(timeout)])
+        let addResult = runHermesCLI(
+            args: ["mcp", "add", name, "--url", url],
+            timeout: 45,
+            stdinInput: "y\ny\ny\n"
+        )
+        guard addResult.exitCode == 0 else { return addResult }
+        // Stamp the SSE transport discriminator (+ optional read timeout)
+        // into the freshly-written entry's YAML block.
+        _ = patchMCPServerField(name: name) { entryLines in
+            Self.replaceOrInsertScalar(key: "transport", value: "sse", in: &entryLines)
+            if let timeout = sseReadTimeout {
+                Self.replaceOrInsertScalar(key: "sse_read_timeout", value: String(timeout), in: &entryLines)
+            }
         }
-        return runHermesCLI(args: cliArgs, timeout: 45, stdinInput: "y\ny\ny\n")
+        return addResult
     }
 
     /// Updates the `sse_read_timeout` scalar in-place via the same surgical

--- a/scarf/scarf/Core/Services/HermesFileService.swift
+++ b/scarf/scarf/Core/Services/HermesFileService.swift
@@ -302,8 +302,7 @@ struct HermesFileService: Sendable {
         // `ScarfCore/Parsing/HermesConfig+YAML.swift`. Behaviour parity
         // matters: both parsers must populate `gatewayPlatforms` the same
         // way so iOS and Mac surfaces stay in lockstep.
-        // TODO(WS-5-Q2): YAML key path unverified — see the comment in the
-        // ScarfCore extractor for the resolution path.
+        // Allowlists live at top-level `<platform>.allowed_*` (verified v0.16).
         let gatewayAllowlistPlatforms = [
             "slack", "mattermost", "google-chat",
             "telegram", "whatsapp",
@@ -311,7 +310,7 @@ struct HermesFileService: Sendable {
         ]
         var gatewayPlatforms: [String: GatewayPlatformSettings] = [:]
         for platform in gatewayAllowlistPlatforms {
-            let prefix = "gateway.platforms.\(platform)."
+            let prefix = "\(platform)."
             let allowedChannels = lists[prefix + "allowed_channels"] ?? []
             let allowedChats    = lists[prefix + "allowed_chats"]    ?? []
             let allowedRooms    = lists[prefix + "allowed_rooms"]    ?? []

--- a/scarf/scarf/Features/Kanban/ViewModels/KanbanBoardViewModel.swift
+++ b/scarf/scarf/Features/Kanban/ViewModels/KanbanBoardViewModel.swift
@@ -419,29 +419,11 @@ final class KanbanBoardViewModel {
 
     // MARK: - Hallucination gate (v0.13)
 
-    /// User confirmed the worker-created card is real. Optimistically
-    /// flip the gate to `verified` so the banner disappears immediately;
-    /// the polling loop confirms the new state on the next tick. On
-    /// failure (e.g. the verb name is wrong on this v0.13.x build), the
-    /// override is cleared and the error surfaces in `lastError`.
-    func verifyHallucination(taskId: String) {
-        var override = optimisticOverrides[taskId] ?? OptimisticOverride()
-        override.hallucinationGate = .verified
-        optimisticOverrides[taskId] = override
-        Task {
-            do {
-                try await service.verify(taskId: taskId)
-                await refresh()
-            } catch let err as KanbanError {
-                clearHallucinationOverride(for: taskId)
-                lastError = err.errorDescription
-                logger.warning("kanban verify failed: \(err.errorDescription ?? "", privacy: .public)")
-            } catch {
-                clearHallucinationOverride(for: taskId)
-                lastError = error.localizedDescription
-            }
-        }
-    }
+    // NOTE: there is no "Verify" action — Hermes has no `kanban verify`
+    // verb (re-verified against v0.16). The gate's only user-driven
+    // action is Reject (below), which archives the card with an audit
+    // comment. The polling loop still reads back a `verified` gate state
+    // if Hermes flips it server-side.
 
     /// User rejected the worker-created card as a hallucinated reference.
     /// Routes through `comment` + `archive` per `KanbanService.rejectHallucinated`
@@ -515,18 +497,6 @@ final class KanbanBoardViewModel {
     private func clearStatusOverride(for taskId: String) {
         guard var override = optimisticOverrides[taskId] else { return }
         override.status = nil
-        if override.isEmpty {
-            optimisticOverrides.removeValue(forKey: taskId)
-        } else {
-            optimisticOverrides[taskId] = override
-        }
-    }
-
-    /// Drop the hallucination-gate side of a task's override (preserving
-    /// any in-flight status-side drag-drop).
-    private func clearHallucinationOverride(for taskId: String) {
-        guard var override = optimisticOverrides[taskId] else { return }
-        override.hallucinationGate = nil
         if override.isEmpty {
             optimisticOverrides.removeValue(forKey: taskId)
         } else {

--- a/scarf/scarf/Features/Kanban/Views/KanbanBoardView.swift
+++ b/scarf/scarf/Features/Kanban/Views/KanbanBoardView.swift
@@ -406,9 +406,6 @@ struct KanbanBoardView: View {
                 onReassign: { profile in
                     viewModel.reassignTask(taskId: taskId, to: profile)
                 },
-                onVerifyHallucination: {
-                    viewModel.verifyHallucination(taskId: taskId)
-                },
                 onRejectHallucination: {
                     viewModel.rejectHallucination(taskId: taskId)
                     // Card vanishes from active board after archive — close

--- a/scarf/scarf/Features/Kanban/Views/KanbanInspectorPane.swift
+++ b/scarf/scarf/Features/Kanban/Views/KanbanInspectorPane.swift
@@ -29,7 +29,6 @@ struct KanbanInspectorPane: View {
     let onUnblock: () -> Void
     let onArchive: () -> Void
     let onReassign: (String?) -> Void
-    let onVerifyHallucination: () -> Void
     let onRejectHallucination: () -> Void
 
     @State private var selectedTab: DetailTab = .comments
@@ -56,7 +55,6 @@ struct KanbanInspectorPane: View {
         onUnblock: @escaping () -> Void,
         onArchive: @escaping () -> Void,
         onReassign: @escaping (String?) -> Void = { _ in },
-        onVerifyHallucination: @escaping () -> Void = {},
         onRejectHallucination: @escaping () -> Void = {}
     ) {
         _viewModel = State(initialValue: KanbanTaskDetailViewModel(service: service, taskId: taskId))
@@ -71,7 +69,6 @@ struct KanbanInspectorPane: View {
         self.onUnblock = onUnblock
         self.onArchive = onArchive
         self.onReassign = onReassign
-        self.onVerifyHallucination = onVerifyHallucination
         self.onRejectHallucination = onRejectHallucination
     }
 
@@ -404,23 +401,23 @@ struct KanbanInspectorPane: View {
         }
     }
 
-    /// v0.13 hallucination-gate banner — Verify / Reject affordances for
-    /// worker-created cards waiting on user verification.
+    /// v0.13 hallucination-gate banner — Reject affordance for
+    /// worker-created cards waiting on user review. (Hermes has no
+    /// `kanban verify` verb, so there is no Verify action; Reject
+    /// archives the card with an audit comment.)
     private var hallucinationBanner: some View {
         HStack(alignment: .top, spacing: ScarfSpace.s2) {
             Image(systemName: "questionmark.diamond.fill")
                 .foregroundStyle(ScarfColor.warning)
                 .font(.system(size: 13, weight: .semibold))
             VStack(alignment: .leading, spacing: 4) {
-                Text("Created by a worker — verify before running")
+                Text("Created by a worker — review before running")
                     .scarfStyle(.captionStrong)
                     .foregroundStyle(ScarfColor.foregroundPrimary)
-                Text("A worker claimed it created this card; Hermes hasn't confirmed the underlying work exists. Verify the card matches a real follow-up, or reject if it's a hallucinated reference.")
+                Text("A worker claimed it created this card; Hermes hasn't confirmed the underlying work exists. Reject it if it's a hallucinated reference.")
                     .scarfStyle(.caption)
                     .foregroundStyle(ScarfColor.foregroundMuted)
                 HStack(spacing: ScarfSpace.s2) {
-                    Button("Verify", action: onVerifyHallucination)
-                        .buttonStyle(ScarfPrimaryButton())
                     Button("Reject", action: onRejectHallucination)
                         .buttonStyle(ScarfDestructiveButton())
                 }

--- a/scarf/scarf/Features/Settings/ViewModels/SettingsViewModel.swift
+++ b/scarf/scarf/Features/Settings/ViewModels/SettingsViewModel.swift
@@ -268,14 +268,15 @@ final class SettingsViewModel {
     /// invoke this setter.
     func setImageGenModel(_ value: String) { setSetting("image_gen.model", value: value) }
 
-    /// `openrouter.response_cache.enabled` — toggles OpenRouter
-    /// response caching for repeat prompts (Hermes v0.13+).
-    /// Capability-gated in `AuxiliaryTab` so pre-v0.13 hosts never
-    /// invoke this setter.
-    // TODO(WS-6-Q1): the YAML key path is provisional — keep in lockstep
-    // with `HermesConfig+YAML.swift`'s parser line.
+    /// `openrouter.response_cache` — toggles OpenRouter response caching
+    /// for repeat prompts. Hermes v0.16 reads this as a SCALAR bool
+    /// directly under `openrouter:` (writing the nested `.enabled` shape
+    /// would be read as a truthy dict, so disabling it would silently
+    /// stay on). Capability-gated in `AuxiliaryTab` so pre-v0.13 hosts
+    /// never invoke this setter. Keep in lockstep with the parser line in
+    /// `HermesConfig+YAML.swift`.
     func setOpenRouterResponseCache(_ value: Bool) {
-        setSetting("openrouter.response_cache.enabled", value: value ? "true" : "false")
+        setSetting("openrouter.response_cache", value: value ? "true" : "false")
     }
 
     // MARK: - Security / Privacy


### PR DESCRIPTION
Fixes the Hermes v0.16 wire mismatches from the WS-* audit — **each re-verified against the live v0.16 source** before changing code.

### Gateway (critical)
- **Allowlists** read/written at top-level `<platform>.allowed_*` (Hermes never read `gateway.platforms.<p>.*`, so Scarf-set allowlists silently never applied); merges into the existing platform section, siblings preserved. DingTalk corrected to `allowed_chats`.
- **`hermes gateway list`**: dropped the non-existent `--json` (it errors) and parse the text table, so the gateway digest works instead of silently hiding.

### Non-critical
- **Kanban**: removed the dead `verify` verb (no such subcommand); Reject routes through the real `comment` + `archive`.
- **Curator**: dropped the non-existent `--json` on `list-archived`.
- **OpenRouter**: `response_cache` is a scalar bool — the nested `.enabled` shape meant a *disable* wrote a truthy dict Hermes still read as on.
- **MCP SSE**: `mcp add --url` then YAML-stamp `transport: sse` (no `--transport`/`--sse-read-timeout` flags exist).
- **ACP `/goal` + `/subgoal`**: removed from the ACP slash menu (gateway-only; they no-op over ACP). Goal-pill plumbing left intact.

**Build SUCCEEDED; 630 ScarfCore tests pass.**
