### PR TITLE
fix(ios): synthesize prompt completion from send result (gh#124)

### DIFF
--- a/scarf/Scarf iOS/Chat/ChatView.swift
+++ b/scarf/Scarf iOS/Chat/ChatView.swift
@@ -1700,7 +1700,19 @@ final class ChatController {
         // literally. v2.5.
         let wireText = expandIfProjectScoped(text)
         do {
-            _ = try await client.sendPrompt(sessionId: sessionId, text: wireText, images: images)
+            let result = try await client.sendPrompt(
+                sessionId: sessionId,
+                text: wireText,
+                images: images
+            )
+            // `promptComplete` is a Scarf-local lifecycle event, not a
+            // `session/update` notification emitted by ACP. Mirror the
+            // macOS controller by synthesizing it from the resolved
+            // `session/prompt` result so the shared VM finalizes the
+            // streaming message and clears its working state.
+            vm.handleACPEvent(
+                .promptComplete(sessionId: sessionId, response: result)
+            )
         } catch {
             // gh#108: a send in flight when the user switches apps
             // gets cancelled by pauseInBackground tearing down the
@@ -1728,6 +1740,15 @@ final class ChatController {
             if case .ready = state {
                 state = .failed("Prompt failed: \(error.localizedDescription)")
             }
+            vm.handleACPEvent(
+                .promptComplete(sessionId: sessionId, response: ACPPromptResult(
+                    stopReason: "error",
+                    inputTokens: 0,
+                    outputTokens: 0,
+                    thoughtTokens: 0,
+                    cachedReadTokens: 0
+                ))
+            )
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #124.

The iOS chat controller discarded the `ACPPromptResult` returned by `sendPrompt`, even though ACP does not emit `.promptComplete` through the session update stream. This left the shared chat view model without the local completion signal it needs to finalize the streaming assistant message and clear the working state.

This change mirrors the existing macOS lifecycle handling:

- Capture the successful `sendPrompt` result and synthesize `.promptComplete`.
- Synthesize an error completion after non-reconnect prompt failures so the shared view model also exits the working state on errors.

The diff is intentionally limited to this completion handoff in the iOS `ChatController`; it does not include other fork features or branding changes.

## Verification

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -quiet -project scarf/scarf.xcodeproj -scheme 'scarf mobile' -destination 'generic/platform=iOS Simulator' build CODE_SIGNING_ALLOWED=NO`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path scarf/Packages/ScarfCore --filter M0dViewModelsTests` — 19 tests passed
