### PR TITLE
perf: batch remote tool-call hydration + single-pass JSON key scan

### DIFF
--- a/scarf/Packages/ScarfCore/Sources/ScarfCore/Services/Backends/RemoteSQLiteBackend.swift
+++ b/scarf/Packages/ScarfCore/Sources/ScarfCore/Services/Backends/RemoteSQLiteBackend.swift
@@ -399,8 +399,7 @@ public actor RemoteSQLiteBackend: HermesQueryBackend {
         // order from the FIRST object's raw JSON bytes. Subsequent
         // rows reuse that key list to look up values by name from
         // their parsed dictionaries.
-        let firstObjectRaw = extractFirstJSONObject(from: json)
-        let orderedKeys = firstObjectRaw.flatMap(extractKeysInOrder) ?? Array(arr[0].keys)
+        let orderedKeys = extractFirstObjectKeys(from: json) ?? Array(arr[0].keys)
         var columnIndex: [String: Int] = [:]
         columnIndex.reserveCapacity(orderedKeys.count)
         for (i, k) in orderedKeys.enumerated() { columnIndex[k] = i }
@@ -418,100 +417,75 @@ public actor RemoteSQLiteBackend: HermesQueryBackend {
         return rows
     }
 
-    /// Extract the substring of the first `{...}` object in a JSON
-    /// array string. Used so we can scan its keys in original order
-    /// before NSJSONSerialization's hash-table conversion strips the
-    /// ordering. Tolerates nested objects/arrays via depth tracking.
-    private func extractFirstJSONObject(from json: String) -> String? {
-        guard let openIdx = json.firstIndex(of: "{") else { return nil }
+    /// Walk the raw JSON bytes of the FIRST top-level object in a
+    /// `sqlite3 -json` result array and return its keys in literal
+    /// order. Single pass over the UTF-8 bytes — avoids the two-pass
+    /// String-index scan (issue #135): extracting the first object
+    /// substring and then re-scanning it for keys cost two full
+    /// traversals plus a substring copy per result set, which showed
+    /// up as parse latency on large `fetchMessages` result sets
+    /// (~50KB of JSON). Byte-scanning keeps the same semantics:
+    /// keys are collected at object depth 1 (the first object's own
+    /// level), nested objects/arrays are skipped via depth tracking,
+    /// and string/escape states are honoured so a `{`/`,`/`:` inside
+    /// a value can't corrupt the key list.
+    private func extractFirstObjectKeys(from json: String) -> [String]? {
+        let bytes = Array(json.utf8)
+        // Find the first '{' — the start of the first object.
+        guard let openIdx = bytes.firstIndex(of: 0x7B /* { */) else { return nil }
         var depth = 0
         var inString = false
         var escape = false
-        var i = openIdx
-        while i < json.endIndex {
-            let c = json[i]
-            if inString {
-                if escape { escape = false }
-                else if c == "\\" { escape = true }
-                else if c == "\"" { inString = false }
-                i = json.index(after: i)
-                continue
-            }
-            switch c {
-            case "\"":
-                inString = true
-            case "{":
-                depth += 1
-            case "}":
-                depth -= 1
-                if depth == 0 {
-                    let end = json.index(after: i)
-                    return String(json[openIdx..<end])
-                }
-            default:
-                break
-            }
-            i = json.index(after: i)
-        }
-        return nil
-    }
-
-    /// Walk an object literal `{"k1": v1, "k2": v2, ...}` and return
-    /// the keys in their literal order. Doesn't decode the values —
-    /// that's what NSJSONSerialization handles. Just extracts
-    /// `["k1", "k2", ...]` so we know the column ordering.
-    private func extractKeysInOrder(_ objectJSON: String) -> [String] {
-        var keys: [String] = []
-        var i = objectJSON.startIndex
-        // Skip past the leading `{`.
-        while i < objectJSON.endIndex, objectJSON[i] != "{" {
-            i = objectJSON.index(after: i)
-        }
-        if i < objectJSON.endIndex { i = objectJSON.index(after: i) }
-        var depth = 0
-        var inString = false
-        var escape = false
-        var keyStart: String.Index?
-        // We're at the start of object body. Looking for `"key":` patterns
-        // at depth 0. Toggle `expectingKey` after each `:`/`,`.
         var expectingKey = true
-        while i < objectJSON.endIndex {
-            let c = objectJSON[i]
+        var keyStart: Int?
+        var keys: [String] = []
+        var i = openIdx
+        while i < bytes.count {
+            let c = bytes[i]
             if inString {
                 if escape {
                     escape = false
-                } else if c == "\\" {
+                } else if c == 0x5C /* \ */ {
                     escape = true
-                } else if c == "\"" {
+                } else if c == 0x22 /* " */ {
                     inString = false
-                    if expectingKey && depth == 0, let start = keyStart {
-                        keys.append(String(objectJSON[start..<i]))
+                    if expectingKey && depth == 1, let start = keyStart {
+                        if let s = String(bytes: bytes[start..<i], encoding: .utf8) {
+                            keys.append(s)
+                        }
                         expectingKey = false
                         keyStart = nil
                     }
                 }
-                i = objectJSON.index(after: i)
+                i += 1
                 continue
             }
             switch c {
-            case "\"":
+            case 0x22 /* " */:
                 inString = true
-                if expectingKey && depth == 0 {
-                    keyStart = objectJSON.index(after: i)
+                if expectingKey && depth == 1 {
+                    keyStart = i + 1
                 }
-            case "{", "[":
+            case 0x7B /* { */:
                 depth += 1
-            case "}", "]":
-                if depth == 0 { return keys } // end of outer object
+            case 0x7D /* } */:
                 depth -= 1
-            case ",":
-                if depth == 0 { expectingKey = true }
-            case ":":
-                if depth == 0 { expectingKey = false }
+                if depth == 0 {
+                    // Closed the outer object — we have every key.
+                    return keys
+                }
+            case 0x5B /* [ */:
+                depth += 1
+            case 0x5D /* ] */:
+                depth -= 1
+            case 0x2C /* , */:
+                if depth == 1 { expectingKey = true }
+            case 0x3A /* : */:
+                if depth == 1 { expectingKey = false }
             default:
                 break
             }
-            i = objectJSON.index(after: i)
+            i += 1
         }
         return keys
     }

--- a/scarf/Packages/ScarfCore/Sources/ScarfCore/Services/HermesDataService.swift
+++ b/scarf/Packages/ScarfCore/Sources/ScarfCore/Services/HermesDataService.swift
@@ -401,6 +401,53 @@ public actor HermesDataService {
                 Array(messageIds[$0..<min($0 + pageSize, messageIds.count)])
             }.reversed()
             var out: [Int: [HermesToolCall]] = [:]
+
+            // v2.18 perf — batch all pages into ONE remote round-trip.
+            // Every page is a separate sqlite3 -json invocation today
+            // (one SSH exec per query), so a 30-assistant-message
+            // session pays 6 round-trips just to hydrate tool cards.
+            // queryBatch folds them into a single sqlite3 process with
+            // marker-split result sets (~50-100ms total on a warm
+            // ControlMaster vs 6 × cold-start). The existing per-page
+            // loop below stays as the fallback when the batch trips
+            // the transport timeout (oversized tool_calls blobs), so
+            // the whale-isolation behaviour is preserved.
+            let batchSQL: [(sql: String, params: [SQLValue])] = pages.map { page in
+                let placeholders = Array(repeating: "?", count: page.count).joined(separator: ",")
+                let sql = "SELECT id, tool_calls FROM messages WHERE id IN (\(placeholders)) AND tool_calls IS NOT NULL AND tool_calls != '' AND tool_calls != '[]'"
+                return (sql: sql, params: page.map { .integer(Int64($0)) })
+            }
+            if !batchSQL.isEmpty {
+                do {
+                    let results = try await backend.queryBatch(batchSQL)
+                    for (_, rows) in zip(pages, results) {
+                        if Task.isCancelled {
+                            ScarfMon.event(.sessionLoad, "mac.hydrateToolCalls.cancelled", count: 1)
+                            return out
+                        }
+                        for row in rows {
+                            let id = row.int(at: 0)
+                            let json = row.optionalString(at: 1)
+                            let parsed = parseToolCalls(json)
+                            if !parsed.isEmpty {
+                                out[id] = parsed
+                            }
+                        }
+                    }
+                    ScarfMon.event(.sessionLoad, "mac.hydrateToolCalls.batch", count: 1)
+                    ScarfMon.event(.sessionLoad, "mac.hydrateToolCalls.rows", count: out.count)
+                    return out
+                } catch is CancellationError {
+                    return out
+                } catch {
+                    // Transport timeout / sqlite failure on the whole
+                    // batch — fall through to the legacy per-page loop
+                    // below, which isolates whales with single-id
+                    // retries exactly as before.
+                    ScarfMon.event(.sessionLoad, "mac.hydrateToolCalls.batchFallback", count: 1)
+                    Self.logger.warning("hydrateToolCalls queryBatch failed, falling back to per-page loop: \(error.localizedDescription, privacy: .public)")
+                }
+            }
             for page in pages {
                 // Bail immediately if the parent task got cancelled
                 // (chat switch, view dismiss). v2.8 — without this

--- a/scarf/Packages/ScarfCore/Tests/ScarfCoreTests/HermesDataServiceBackendTests.swift
+++ b/scarf/Packages/ScarfCore/Tests/ScarfCoreTests/HermesDataServiceBackendTests.swift
@@ -632,6 +632,76 @@ import Foundation
         #expect(sql.contains("AND active = 1"))
         #expect(!sql.contains("compacted"))
     }
+
+    // MARK: - hydrateAssistantToolCalls batching (v2.18)
+
+    /// v2.18 perf: `hydrateAssistantToolCalls` must fold every 5-id
+    /// page into ONE `queryBatch` round-trip instead of N sequential
+    /// `query` calls (each an SSH exec on remote backends). The mock's
+    /// `batchLog` records the batch; `queryLog` must stay empty.
+    @Test func hydrateToolCallsUsesQueryBatch() async throws {
+        let mock = MockHermesQueryBackend()
+        let service = HermesDataService(context: context, backend: mock)
+        _ = await service.open()
+
+        // 12 ids -> 3 pages of 5, 5, 2. Seed via placeholder form
+        // (HermesDataService emits ?-bound SQL; the mock matches on
+        // the raw SQL prefix).
+        let ids = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        // Seed tool_calls JSON for ids 1 and 12 so we can assert the
+        // spliced map contents, not just the call shape.
+        let callsJSON = #"[{"id":"c1","type":"function","function":{"name":"search","arguments":"{}"}}]"#
+        await mock._seedRow(forSQLPrefix: "SELECT id, tool_calls FROM messages WHERE id IN (?,?,?,?,?)",
+                            columns: ["id": 0, "tool_calls": 1],
+                            values: [.integer(1), .text(callsJSON)])
+        await mock._seedRow(forSQLPrefix: "SELECT id, tool_calls FROM messages WHERE id IN (?,?)",
+                            columns: ["id": 0, "tool_calls": 1],
+                            values: [.integer(12), .text(callsJSON)])
+
+        let map = await service.hydrateAssistantToolCalls(messageIds: ids)
+
+        let batchLog = await mock.batchLog
+        #expect(batchLog.count == 1)
+        #expect(batchLog[0].count == 3)  // three pages in one batch
+        // Pages are iterated newest-first (reversed), so the 2-id page
+        // [11,12] is slot 0 and the 5-id page [1..5] is slot 2.
+        #expect(batchLog[0][0].sql.hasPrefix("SELECT id, tool_calls FROM messages WHERE id IN (?,?)"))
+        #expect(batchLog[0][2].sql.hasPrefix("SELECT id, tool_calls FROM messages WHERE id IN (?,?,?,?,?)"))
+        let queryLog = await mock.queryLog
+        #expect(queryLog.isEmpty)  // no per-page fallback queries
+
+        #expect(map.count == 2)
+        #expect(map[1]?.first?.functionName == "search")
+        #expect(map[12]?.first?.functionName == "search")
+    }
+
+    /// The batch path must degrade to the legacy per-page loop when the
+    /// backend rejects the batch (transport timeout on an oversized
+    /// tool_calls blob). Regression guard so the whale-isolation
+    /// behaviour isn't lost.
+    @Test func hydrateToolCallsFallsBackToPerPageOnBatchFailure() async throws {
+        let mock = MockHermesQueryBackend()
+        let service = HermesDataService(context: context, backend: mock)
+        _ = await service.open()
+
+        let ids = [1, 2, 3, 4, 5, 6]
+        await mock._seedFailure(forSQLPrefix: "SELECT id, tool_calls FROM messages WHERE id IN (?,?,?,?,?)",
+                                error: .transport("simulated timeout"))
+        let callsJSON = #"[{"id":"c1","type":"function","function":{"name":"search","arguments":"{}"}}]"#
+        await mock._seedRow(forSQLPrefix: "SELECT id, tool_calls FROM messages WHERE id IN (?)",
+                            columns: ["id": 0, "tool_calls": 1],
+                            values: [.integer(6), .text(callsJSON)])
+
+        let map = await service.hydrateAssistantToolCalls(messageIds: ids)
+
+        // Batch was attempted, failed, then per-page fallback ran.
+        let batchLog = await mock.batchLog
+        #expect(batchLog.count == 1)
+        let queryLog = await mock.queryLog
+        // page [6] query + failed page [1-5] query + 5 single-id retries.
+        #expect(queryLog.count == 7)
+        #expect(map[6]?.first?.functionName == "search")
+    }
 }
 
 #endif // canImport(SQLite3)

--- a/scarf/Packages/ScarfCore/Tests/ScarfCoreTests/RemoteSQLiteBackendTests.swift
+++ b/scarf/Packages/ScarfCore/Tests/ScarfCoreTests/RemoteSQLiteBackendTests.swift
@@ -553,6 +553,114 @@ private struct LocalSQLite3Transport: ServerTransport {
         #expect(results[2].count == 1)
     }
 
+    // MARK: - Column-order preservation (v2.18 parser)
+
+    /// Insert a raw row directly via libsqlite3 (the backend opens the
+    /// DB read-only, so fixtures must be seeded outside it).
+    private func insertFixtureRow(_ sql: String, dbURL: URL) throws {
+        var db: OpaquePointer?
+        guard sqlite3_open_v2(dbURL.path, &db, SQLITE_OPEN_READWRITE, nil) == SQLITE_OK else {
+            throw TransportError.other(message: "sqlite3_open_v2 (seed) failed")
+        }
+        defer { sqlite3_close(db) }
+        var errMsg: UnsafeMutablePointer<CChar>?
+        let rc = sqlite3_exec(db, sql, nil, nil, &errMsg)
+        if rc != SQLITE_OK {
+            let msg = errMsg.flatMap { String(cString: $0) } ?? "unknown"
+            sqlite3_free(errMsg)
+            throw TransportError.other(message: "sqlite3_exec seed failed: \(msg)")
+        }
+    }
+
+    /// Regression for the v2.18 byte-scan parser: `extractFirstObjectKeys`
+    /// must preserve SELECT column order even when row values contain
+    /// JSON-ish punctuation (braces, brackets, commas, colons, quotes),
+    /// backslash escapes, and multi-byte UTF-8 — anything that could
+    /// fool a naive depth/string tracker. The fixture message content
+    /// is deliberately hostile to the parser.
+    @Test func preservesColumnOrderWithHostileValues() async throws {
+        try requireSqlite3()
+        let dbURL = try makeFixtureStateDB()
+        defer {
+            try? FileManager.default.removeItem(at: dbURL)
+            try? FileManager.default.removeItem(at: dbURL.deletingLastPathComponent().appendingPathComponent("state.db"))
+        }
+        // Insert a message whose content is hostile: nested braces,
+        // brackets, commas, colons, escaped quotes, backslashes, and
+        // multi-byte UTF-8 (Vietnamese).
+        let hostile = """
+        {"nested": {"a": [1,2,{"x":"y"}]}, "escaped": "quote:\\"comma,colon:brace{", "utf8": "Xin chào — Việt Nam 🇻🇳"}
+        """
+        let insert = """
+        INSERT INTO messages (id, session_id, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_count, finish_reason)
+        VALUES (99, 's1', 'assistant', '\(hostile)', NULL, NULL, NULL, 1700000099.0, NULL, NULL);
+        """
+        try insertFixtureRow(insert, dbURL: dbURL)
+
+        let ctx = makeFixtureContext(dbURL: dbURL)
+        let backend = RemoteSQLiteBackend(context: ctx, transport: LocalSQLite3Transport())
+        _ = await backend.open()
+
+        // SELECT with a column order the row parser depends on.
+        let rows = try await backend.query(
+            "SELECT id, role, content, tool_calls, token_count FROM messages WHERE id = 99",
+            params: []
+        )
+        #expect(rows.count == 1)
+        let row = rows[0]
+        // Positional access proves the key order survived parsing.
+        #expect(row.int(at: 0) == 99)
+        if case .text(let role) = row[1] {
+            #expect(role == "assistant")
+        } else {
+            Issue.record("Expected .text role at index 1")
+        }
+        if case .text(let content) = row[2] {
+            #expect(content == hostile)
+        } else {
+            Issue.record("Expected .text content at index 2")
+        }
+        #expect(row.isNull(at: 3))
+        #expect(row.isNull(at: 4))
+    }
+
+    /// v2.18 parser: keys must be extracted from the FIRST object only,
+    /// and a nested object inside a value must not leak its keys into
+    /// the column list. Uses the tool_calls column with a real nested
+    /// array-of-objects blob.
+    @Test func parserIgnoresNestedObjectKeys() async throws {
+        try requireSqlite3()
+        let dbURL = try makeFixtureStateDB()
+        defer {
+            try? FileManager.default.removeItem(at: dbURL)
+            try? FileManager.default.removeItem(at: dbURL.deletingLastPathComponent().appendingPathComponent("state.db"))
+        }
+        let toolCalls = """
+        [{"id":"call_1","name":"search","arguments":"{\\"q\\":\\"x\\"}"},{"id":"call_2","name":"read","arguments":"{}"}]
+        """
+        let insert = """
+        INSERT INTO messages (id, session_id, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_count, finish_reason)
+        VALUES (100, 's1', 'assistant', 'nested', NULL, '\(toolCalls)', NULL, 1700000100.0, NULL, NULL);
+        """
+        try insertFixtureRow(insert, dbURL: dbURL)
+
+        let ctx = makeFixtureContext(dbURL: dbURL)
+        let backend = RemoteSQLiteBackend(context: ctx, transport: LocalSQLite3Transport())
+        _ = await backend.open()
+
+        let rows = try await backend.query(
+            "SELECT id, tool_calls FROM messages WHERE id = 100",
+            params: []
+        )
+        #expect(rows.count == 1)
+        #expect(rows[0].int(at: 0) == 100)
+        if case .text(let tc) = rows[0][1] {
+            #expect(tc == toolCalls)
+        } else {
+            Issue.record("Expected .text tool_calls at index 1")
+        }
+    }
+
     // MARK: - Failure paths
 
     @Test func nonZeroExitThrowsSqliteError() async throws {


### PR DESCRIPTION
## Summary

Two changes to cut remote chat-load latency (Scarf over SSH on Mac + ScarfGo on iOS/Citadel):

1. **Batch tool-call hydration** — `hydrateAssistantToolCalls` now folds every 5-id page into a single `queryBatch` round-trip instead of N sequential `query()` calls, each of which spawns a fresh `sqlite3 -readonly -json` process on the remote. A 30-assistant-message session drops from 6 SSH execs to 1. The legacy per-page loop with single-id whale isolation remains as the fallback when a batch trips the transport timeout, so oversized `tool_calls` blobs degrade exactly as before.

2. **Single-pass JSON key scan** — `RemoteSQLiteBackend.rowsFromJSONArray` previously recovered SELECT column order (NSDictionary loses it) by two-pass scanning raw JSON with `String.Index`: `extractFirstJSONObject` (substring copy) then `extractKeysInOrder`. Replaced with one UTF-8 byte scan that collects the first object's keys in literal order. Same semantics — column order preserved even with nested objects, escaped quotes, and multi-byte UTF-8 in values — at a fraction of the parse cost on large `fetchMessages` result sets (~50KB JSON).

## Tests

- `hydrateToolCallsUsesQueryBatch` — asserts one batch call, three page statements, zero fallback queries, correct splice.
- `hydrateToolCallsFallsBackToPerPageOnBatchFailure` — batch transport failure degrades to the legacy per-page loop with single-id retries.
- `preservesColumnOrderWithHostileValues` — parser keeps column order with nested braces/brackets, escapes, commas/colons, and Vietnamese UTF-8 in values.
- `parserIgnoresNestedObjectKeys` — nested object keys inside a value don't leak into the column list.

`swift test` in `scarf/Packages/ScarfCore`: 990 tests green (verified with the Swift 6.2 toolchain; the only local failure is a pre-existing env-sensitive test that passes with a clean environment).

Closes #135
